### PR TITLE
Filter for set params for body string

### DIFF
--- a/Rubrik/Private/New-BodyString.ps1
+++ b/Rubrik/Private/New-BodyString.ps1
@@ -9,7 +9,10 @@
   {
     return $null
   }
-  
+
+  $setParameters = $pscmdlet.MyInvocation.BoundParameters
+  Write-Verbose -Message "List of set parameters: $($setParameters.GetEnumerator())"
+
   Write-Verbose -Message 'Build the body parameters'
   $bodystring = @{}
   # Walk through all of the available body options presented by the endpoint
@@ -30,6 +33,7 @@
         foreach ($param in $parameters)
         {
           # If the parameter name or alias matches the body option name, build a body string
+          
           if ($param.Name -eq $arrayitem -or $param.Aliases -eq $arrayitem)
           {
             # Switch variable types
@@ -57,7 +61,7 @@
       foreach ($param in $parameters)
       {
         # If the parameter name or alias matches the body option name, build a body string
-        if ($param.Name -eq $body -or $param.Aliases -eq $body)
+        if (($param.Name -eq $body -or $param.Aliases -eq $body) -and $setParameters.ContainsKey($param.Name))
         {
           # Switch variable types
           if ((Get-Variable -Name $param.Name).Value.GetType().Name -eq 'SwitchParameter')


### PR DESCRIPTION
This PR is largely driven by an issue where PowerShell was passing along parameters to the API endpoint that weren't explicitly set during invocation. Example - if a [bool] value isn't set, it remains `$false`, and is then expressed in the body of the API call as `false` which can cause issues.

The use of ` $pscmdlet.MyInvocation.BoundParameters` allows the private function `New-BodyString` to compare what parameters were invoked with what values need to be set. Thus, if the user doesn't change a [bool] value then it won't be put in the body payload.