### PR TITLE
Syntax error for -RecoveryDateTime parameter conversion. 

### DIFF
--- a/Rubrik/Public/Get-RubrikDatabaseFiles.ps1
+++ b/Rubrik/Public/Get-RubrikDatabaseFiles.ps1
@@ -58,7 +58,7 @@ function Get-RubrikDatabaseFiles
     
     # Check to ensure that a session to the Rubrik cluster exists and load the needed header data for authentication
     Test-RubrikConnection
-    if($RecoveryDateTime){$time = $RecoveryDateTime.ToUniversalTime().ToString('yyyy-dd-MMTHH:mm:ssZ')}
+    if($RecoveryDateTime){$time = $RecoveryDateTime.ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')}
 
     # API data references the name of the function
     # For convenience, that name is saved here to $function


### PR DESCRIPTION
Converting RecoveryDateTime to time was using the wrong format (yyyy-dd-MM). Converted to correct format (yyyy-MM-dd).