### PR TITLE
Fix body creation and SLA assignment

### DIFF
--- a/Rubrik/Private/New-BodyString.ps1
+++ b/Rubrik/Private/New-BodyString.ps1
@@ -10,6 +10,12 @@
     return $null
   }
 
+  # Look at the list of parameters that were set by the invocation process
+  # This is how we know which params were actually set by the call, versus defaulting to some zero, null, or false value
+  # We can also add any custom variables here, such as SLAID which is populated after the invocation resolves the name
+  if ($slaid) {$PSCmdlet.MyInvocation.BoundParameters.Add('SLAID',$slaid)}
+  
+  # Now that custom params are added, let's inventory all invoked params
   $setParameters = $pscmdlet.MyInvocation.BoundParameters
   Write-Verbose -Message "List of set parameters: $($setParameters.GetEnumerator())"
 
@@ -67,7 +73,7 @@
           if ((Get-Variable -Name $param.Name).Value.GetType().Name -eq 'SwitchParameter')
           {
             $bodystring.Add($body,(Get-Variable -Name $param.Name).Value.IsPresent)
-          }
+          }     
           # All other variable types
           elseif ((Get-Variable -Name $param.Name).Value -ne $null -and (Get-Variable -Name $param.Name).Value.Length -gt 0)
           {

--- a/Rubrik/Private/Test-RubrikSLA.ps1
+++ b/Rubrik/Private/Test-RubrikSLA.ps1
@@ -1,4 +1,4 @@
-﻿Function Test-RubrikSLA($SLA,$Inherit,$DoNotProtect)
+﻿Function Test-RubrikSLA($SLA,$Inherit,$DoNotProtect,$Mandatory)
 {
   Write-Verbose -Message 'Determining the SLA Domain id'
   if ($SLA) 
@@ -17,6 +17,10 @@
   if ($DoNotProtect) 
   {
     return 'UNPROTECTED'
+  }
+  if ($Mandatory)
+  {
+    throw 'No SLA information was entered.'
   }
 }
     

--- a/Rubrik/Public/Protect-RubrikVM.ps1
+++ b/Rubrik/Public/Protect-RubrikVM.ps1
@@ -30,7 +30,7 @@ function Protect-RubrikVM
       without asking for confirmation
   #>
 
-  [CmdletBinding(SupportsShouldProcess = $true,ConfirmImpact = 'High')]
+  [CmdletBinding(SupportsShouldProcess = $true,ConfirmImpact = 'High',DefaultParameterSetName="None")]
   Param(
     # Virtual machine ID
     [Parameter(Mandatory = $true,ValueFromPipelineByPropertyName = $true)]
@@ -46,7 +46,7 @@ function Protect-RubrikVM
     [Switch]$Inherit,
     # SLA id value
     [Alias('configuredSlaDomainId')]
-    [String]$SLAID,    
+    [String]$SLAID = (Test-RubrikSLA -SLA $SLA -Inherit $Inherit -DoNotProtect $DoNotProtect -Mandatory:$true),    
     # Rubrik server IP or FQDN
     [String]$Server = $global:RubrikConnection.server,
     # API version
@@ -74,11 +74,7 @@ function Protect-RubrikVM
   }
 
   Process {
-
-    #region One-off
-    $SLAID = Test-RubrikSLA -SLA $SLA -Inherit $Inherit -DoNotProtect $DoNotProtect
-    #endregion One-off
-
+    
     $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $id
     $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
     $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,7 @@ install:
 # Invoke Pester to run all of the unit tests, then save the results into XML in order to populate the AppVeyor tests section
 # If any of the tests fail, consider the pipeline failed
 test_script:
-  - ps: $res = Invoke-Pester -Path ".\Tests" -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru
+  - ps: $res = Invoke-Pester -Path ".\tests" -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru
   - ps: (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\TestsResults.xml))
   - ps: if ($res.FailedCount -gt 0) { throw "$($res.FailedCount) tests failed."}
   - git config --global credential.helper store


### PR DESCRIPTION
* Updated `New-BodyString` with details on how BoundParameters works, while also adding the custom param `$SLAID` to the hashtable if a value is found. This solves body creation issue since `$SLAID` is created within the process block by querying for the SLA's name and is not considered a bound parameter.
* Added a `$Mandatory` flag to the `Test-RubrikSLA` private function to allow invoking functions to require an answer. Set this to `$true` if you must have a return for SLA, Inherit, or DoNotProtect.
* Solved the weird bug where `Protect-RubrikVM` would throw a cryptic error if you didn't specify any SLA information; you now get a helpful message.

Fixes #114 
