### PR TITLE
Update module revision number to AppVeyor build number environment variable

### DIFF
--- a/Tests/build.ps1
+++ b/Tests/build.ps1
@@ -24,7 +24,7 @@ else
         $manifest = Test-ModuleManifest -Path $manifestPath
         [System.Version]$version = $manifest.Version
         Write-Output "Old Version: $version"
-        [String]$newVersion = New-Object -TypeName System.Version -ArgumentList ($version.Major, $version.Minor, $version.Build, ($version.Revision+1))
+        [String]$newVersion = New-Object -TypeName System.Version -ArgumentList ($version.Major, $version.Minor, $version.Build, $env:APPVEYOR_BUILD_NUMBER)
         Write-Output "New Version: $newVersion"
 
         # Update the manifest with the new version value and fix the weird string replace bug


### PR DESCRIPTION
Update module revision number to AppVeyor build number environment variable: $env:APPVEYOR_BUILD_NUMBER so that it will always be accurate.  
 
Fixes #122