### PR TITLE
Get hyperv snap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * [GitHub Issue Template](https://github.com/rubrikinc/PowerShell-Module/commit/ca0a7fc1864c42162236b4e68af6f44d07f0a164).
 * [Invoke-RubrikRESTCall](https://github.com/rubrikinc/PowerShell-Module/pull/118).
 
+### Changed
+
+* The `Get-RubrikSnapshot` function supports HyperV VMs.
+
 ### Deprecated
 
 * Dynamic documentation using ReadTheDocs and reStructuredText.

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -295,6 +295,7 @@ function Get-RubrikAPIData($endpoint)
           Fileset = '/api/v1/fileset/{id}/snapshot'
           MSSQL   = '/api/v1/mssql/db/{id}/snapshot'
           VMware  = '/api/v1/vmware/vm/{id}/snapshot'
+          HyperV  = '/api/internal/hyperv/vm/{id}/snapshot'
         }
         Method      = 'Get'
         Body        = ''

--- a/Rubrik/Private/Test-QueryParam.ps1
+++ b/Rubrik/Private/Test-QueryParam.ps1
@@ -27,6 +27,11 @@
         Write-Verbose -Message 'Loading VMware API data'
         $uri = ('https://'+$Server+$resources.URI.VMware) -replace '{id}', $id
       }
+      'HypervVirtualMachine:::*'
+      {
+        Write-Verbose -Message 'Loading HyperV API data'
+        $uri = ('https://'+$Server+$resources.URI.HyperV) -replace '{id}', $id
+      }
       default
       {
         throw 'The supplied id value has no matching endpoint'


### PR DESCRIPTION
# Description

Updates the `Get-RubrikSnapshot` function to pull HyperV snapshots.

## Related Issue

Resolves #116 

## Motivation and Context

Fixes the lack of ability to get HyperV snapshots.

## How Has This Been Tested?

Tested against RCDM 4.1.0 on Windows 10 against various HyperV workloads that had snapshots. Received this back:

```
id                     : 48031d70-b01b-4e1c-9417-a0248977f417
slaName                : Gold
slaId                  : cb48d4e8-8559-484b-a6a2-4a059bf1f0f5
replicationLocationIds : 
cloudState             : 2
indexState             : 1
isOnDemandSnapshot     : True
archivalLocationIds    : f9c1aac5-3547-4e9e-a8ae-22d2e844d41f
date                   : 2017-07-09T14:31:53Z
vmName                 : DEMO-EXCH13-1
```

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
