### PR TITLE
Add Support Tunnel functions and user_error details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+* `Set-RubrikSupportTunnel` - Modifies the configuration of the Support Tunnel.
+* `Get-RubrikSupportTunnel` - Checks the status of the Support Tunnel.
 * This Changelog - moving forward, related changes will be documented here in an easy to read format for human eyeballs.
 * Dynamic documentation creation via GitBook.
 * [GitHub Pull Request Template](https://github.com/rubrikinc/PowerShell-Module/pull/135).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+* Track `user_error` responses in the `Submit-Request` private function
 * The `Get-RubrikSnapshot` function supports HyperV VMs.
 
 ### Deprecated

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -337,7 +337,19 @@ function Get-RubrikAPIData($endpoint)
         }
         Success     = '200'
       }
-    }    
+    }
+    'Get-RubrikSupportTunnel' = @{
+      v1 = @{
+        Description = 'To be used by Admin to check status of the support tunnel.'
+        URI         = '/api/internal/node/me/support_tunnel'
+        Method      = 'Get'
+        Body        = ''
+        Query       = ''
+        Result      = ''
+        Filter      = ''
+        Success     = '200'
+      }
+    }     
     'Get-RubrikUnmanagedObject'  = @{
       v1 = @{
         Description = 'Get summary of all the objects with unmanaged snapshots'

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -783,7 +783,22 @@ function Get-RubrikAPIData($endpoint)
         Filter      = ''
         Success     = '200'
       }
-    }    
+    }
+    'Set-RubrikSupportTunnel'         = @{
+      v1 = @{
+        Description = 'To be used by Admin to open or close a SSH tunnel for support.'
+        URI         = '/api/internal/node/me/support_tunnel'
+        Method      = 'Patch'
+        Body        = @{
+          isTunnelEnabled = "isTunnelEnabled"
+          inactivityTimeoutInSeconds = "inactivityTimeoutInSeconds"
+        }
+        Query       = ''
+        Result      = ''
+        Filter      = ''
+        Success     = '200'
+      }
+    }     
     'Set-RubrikVM'               = @{
       v1 = @{
         Description = 'Update VM with specified properties'

--- a/Rubrik/Private/Submit-Request.ps1
+++ b/Rubrik/Private/Submit-Request.ps1
@@ -1,40 +1,41 @@
-﻿function Submit-Request($uri,$header,$method = $($resources.Method) ,$body)
-{
-  # The Submit-Request function is used to send data to an endpoint and then format the response for further use
-  # $uri = The endpoint's URI
-  # $header = The header containing authentication details
-  # $method = The action (method) to perform on the endpoint
-  # $body = Any optional body data being submitted to the endpoint
+﻿function Submit-Request($uri, $header, $method = $($resources.Method) , $body) {
+    # The Submit-Request function is used to send data to an endpoint and then format the response for further use
+    # $uri = The endpoint's URI
+    # $header = The header containing authentication details
+    # $method = The action (method) to perform on the endpoint
+    # $body = Any optional body data being submitted to the endpoint
 
-  if ($PSCmdlet.ShouldProcess($id,$resources.Description))
-  {
-    try 
-    {
-      Write-Verbose -Message 'Submitting the request'
-      # Because some calls require more than the default payload limit of 2MB, ExpandPayload dynamically adjusts the payload limit
-      $result = ExpandPayload -response (Invoke-WebRequest -Uri $uri -Headers $header -Method $method -Body $body)
-    }
-    catch 
-    {
-      switch -Wildcard ($_)
-      {
-        'Route not defined.'
-        {
-          Write-Warning -Message "The endpoint supplied to Rubrik is invalid. Likely this is due to an incompatible version of the API or references pointing to a non-existent endpoint. The URI passed was: $uri" -Verbose
-          throw $_.Exception 
+    if ($PSCmdlet.ShouldProcess($id, $resources.Description)) {
+        try {
+            Write-Verbose -Message 'Submitting the request'
+            # Because some calls require more than the default payload limit of 2MB, ExpandPayload dynamically adjusts the payload limit
+            $result = ExpandPayload -response (Invoke-WebRequest -Uri $uri -Headers $header -Method $method -Body $body)
         }
-        'Invalid ManagedId*'
-        {
-          Write-Warning -Message "The endpoint supplied to Rubrik is invalid. Likely this is due to an incompatible version of the API or references pointing to a non-existent endpoint. The URI passed was: $uri" -Verbose
-          throw $_.Exception 
+        catch {
+            switch -Wildcard ($_) {
+                'Route not defined.' {
+                    Write-Warning -Message "The endpoint supplied to Rubrik is invalid. Likely this is due to an incompatible version of the API or references pointing to a non-existent endpoint. The URI passed was: $uri" -Verbose
+                    throw $_.Exception 
+                }
+                'Invalid ManagedId*' {
+                    Write-Warning -Message "The endpoint supplied to Rubrik is invalid. Likely this is due to an incompatible version of the API or references pointing to a non-existent endpoint. The URI passed was: $uri" -Verbose
+                    throw $_.Exception 
+                }
+                '{"errorType":*' {
+                    # Parses the Rubrik generated JSON warning into something a bit more human readable
+                    # Fields are: errorType, message, and cause
+                    [Array]$rubrikWarning = ConvertFrom-Json $_.ErrorDetails.Message
+                    if ($rubrikWarning.errorType) {Write-Warning -Message $rubrikWarning.errorType}
+                    if ($rubrikWarning.message) {Write-Warning -Message $rubrikWarning.message}
+                    if ($rubrikWarning.cause) {Write-Warning -Message $rubrikWarning.cause}
+                    throw $_.Exception
+                }
+                default {
+                    throw $_
+                }
+            }
         }
-        default
-        {
-          throw $_
-        }
-      }
-    }
     
-    return $result
-  }
+        return $result
+    }
 }

--- a/Rubrik/Public/Get-RubrikSupportTunnel.ps1
+++ b/Rubrik/Public/Get-RubrikSupportTunnel.ps1
@@ -1,0 +1,65 @@
+﻿#requires -Version 3
+function Get-RubrikSupportTunnel
+{
+  <#  
+      .SYNOPSIS
+      Checks the status of the Support Tunnel
+
+      .DESCRIPTION
+      The Get-RubrikSupportTunnel cmdlet is used to query the Rubrik cluster to determine the status of the Support Tunnel
+      This tunnel is used by Rubrik's support team for providing remote assistance and is toggled on or off by the cluster administrator
+
+      .NOTES
+      Written by Chris Wahl for community usage
+      Twitter: @ChrisWahl
+      GitHub: chriswahl
+
+      .LINK
+      https://github.com/rubrikinc/PowerShell-Module
+
+      .EXAMPLE
+      Get-RubrikSupportTunnel
+      This will return details on the configuration of the Support Tunnel for the currently connected Rubrik cluster
+  #>
+
+  [CmdletBinding()]
+  Param(
+    # Rubrik server IP or FQDN
+    [String]$Server = $global:RubrikConnection.server,
+    # API version
+    [String]$api = $global:RubrikConnection.api
+  )
+
+  Begin {
+
+    # The Begin section is used to perform one-time loads of data necessary to carry out the function's purpose
+    # If a command needs to be run with each iteration or pipeline input, place it in the Process section
+    
+    # Check to ensure that a session to the Rubrik cluster exists and load the needed header data for authentication
+    Test-RubrikConnection
+    
+    # API data references the name of the function
+    # For convenience, that name is saved here to $function
+    $function = $MyInvocation.MyCommand.Name
+        
+    # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
+    Write-Verbose -Message "Gather API Data for $function"
+    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    Write-Verbose -Message "Load API data for $($resources.Function)"
+    Write-Verbose -Message "Description: $($resources.Description)"
+  
+  }
+
+  Process {
+
+    $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $id
+    $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
+    $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)
+    $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
+    $result = Test-ReturnFormat -api $api -result $result -location $resources.Result
+    $result = Test-FilterObject -filter ($resources.Filter) -result $result
+
+    return $result
+
+  } # End of process
+} # End of function

--- a/Rubrik/Public/Set-RubrikSupportTunnel.ps1
+++ b/Rubrik/Public/Set-RubrikSupportTunnel.ps1
@@ -1,0 +1,80 @@
+﻿#requires -Version 3
+function Set-RubrikSupportTunnel
+{
+  <#  
+      .SYNOPSIS
+      Sets the configuration of the Support Tunnel
+
+      .DESCRIPTION
+      The Set-RubrikSupportTunnel cmdlet is used to update a Rubrik cluster's Support Tunnel configuration
+      This tunnel is used by Rubrik's support team for providing remote assistance and is toggled on or off by the cluster administrator
+
+      .NOTES
+      Written by Chris Wahl for community usage
+      Twitter: @ChrisWahl
+      GitHub: chriswahl
+
+      .LINK
+      https://github.com/rubrikinc/PowerShell-Module
+
+      .EXAMPLE
+      Set-RubrikSupportTunnel -EnableTunnel $false
+      This will disable the Support Tunnel for the Rubrik cluster
+
+      .EXAMPLE
+      Set-RubrikSupportTunnel -EnableTunnel $true
+      This will enable the Support Tunnel for the Rubrik cluster and set the inactivity timeout to infinite (no timeout)
+
+      .EXAMPLE
+      Set-RubrikSupportTunnel -EnableTunnel $true -Timeout 100
+      This will enable the Support Tunnel for the Rubrik cluster and set the inactivity timeout to 100 seconds
+  #>
+
+  [CmdletBinding()]
+  Param(
+    # Status of the Support Tunnel. Choose $true to enable or $false to disable.
+    [Parameter(Mandatory = $true)]
+    [Alias('isTunnelEnabled')]
+    [Bool]$EnableTunnel,
+    # Tunnel inactivity timeout in seconds. Only valid when setting $EnableTunnel to $true.
+    [Alias('inactivityTimeoutInSeconds')]
+    [int]$Timeout,    
+    # Rubrik server IP or FQDN
+    [String]$Server = $global:RubrikConnection.server,
+    # API version
+    [String]$api = $global:RubrikConnection.api
+  )
+
+  Begin {
+
+    # The Begin section is used to perform one-time loads of data necessary to carry out the function's purpose
+    # If a command needs to be run with each iteration or pipeline input, place it in the Process section
+    
+    # Check to ensure that a session to the Rubrik cluster exists and load the needed header data for authentication
+    Test-RubrikConnection
+    
+    # API data references the name of the function
+    # For convenience, that name is saved here to $function
+    $function = $MyInvocation.MyCommand.Name
+        
+    # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
+    Write-Verbose -Message "Gather API Data for $function"
+    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    Write-Verbose -Message "Load API data for $($resources.Function)"
+    Write-Verbose -Message "Description: $($resources.Description)"
+  
+  }
+
+  Process {
+
+    $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $id
+    $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
+    $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)
+    $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
+    $result = Test-ReturnFormat -api $api -result $result -location $resources.Result
+    $result = Test-FilterObject -filter ($resources.Filter) -result $result
+
+    return $result
+
+  } # End of process
+} # End of function

--- a/Rubrik/Rubrik.psd1
+++ b/Rubrik/Rubrik.psd1
@@ -73,7 +73,7 @@ FunctionsToExport = @('Connect-Rubrik', 'Disconnect-Rubrik', 'Export-RubrikDatab
                'Get-RubrikMount', 'Get-RubrikReport', 'Get-RubrikReportData', 
                'Get-RubrikRequest', 'Get-RubrikSLA', 'Get-RubrikSnapshot', 
                'Get-RubrikSoftwareVersion', 'Get-RubrikSQLInstance', 
-               'Get-RubrikUnmanagedObject', 'Get-RubrikVersion', 'Get-RubrikVM', 
+               'Get-RubrikUnmanagedObject', 'Get-RubrikVersion', 'Get-RubrikVM', 'Get-RubrikSupportTunnel', 
                'Invoke-RubrikRESTCall', 'Move-RubrikMountVMDK', 
                'New-RubrikDatabaseMount', 'New-RubrikHost', 'New-RubrikMount', 
                'New-RubrikReport', 'New-RubrikSLA', 'New-RubrikSnapshot', 

--- a/Rubrik/Rubrik.psd1
+++ b/Rubrik/Rubrik.psd1
@@ -83,7 +83,7 @@ FunctionsToExport = @('Connect-Rubrik', 'Disconnect-Rubrik', 'Export-RubrikDatab
                'Remove-RubrikReport', 'Remove-RubrikSLA', 
                'Remove-RubrikUnmanagedObject', 'Restore-RubrikDatabase', 
                'Set-RubrikBlackout', 'Set-RubrikDatabase', 'Set-RubrikMount', 
-               'Set-RubrikSQLInstance', 'Set-RubrikVM', 'Sync-RubrikAnnotation', 
+               'Set-RubrikSQLInstance', 'Set-RubrikVM', 'Sync-RubrikAnnotation', 'Set-RubrikSupportTunnel',
                'Sync-RubrikTag')
 
 # Cmdlets to export from this module


### PR DESCRIPTION
# Description

There is currently no commands to view or manage the Support Tunnel configuration. This adds the two missing functions while also making `user_error` events more visible when submitting requests.

## Related Issue

Resolves #117 

## Motivation and Context

Missing functionality and more details when hitting user errors that are returned during a 422 (Unprocessable Entity) submits.

## How Has This Been Tested?

Used RCDM 4.1 against Windows 10 to enable and disable the cluster's Support Tunnel.

Getting details on the tunnel -

```
Get-RubrikSupportTunnel


inactivityTimeoutInSeconds : 
lastActivityTime           : 2017-12-08T17:36:46Z
port                       : 27208
enabledTime                : 2017-12-09T04:57:55Z
isTunnelEnabled            : True
```

Enabling the tunnel -

```
Set-RubrikSupportTunnel -EnableTunnel $true


inactivityTimeoutInSeconds : 
lastActivityTime           : 2017-12-08T17:36:46Z
port                       : 27208
enabledTime                : 2017-12-09T05:05:37Z
isTunnelEnabled            : True
```

Disabling the tunnel -

```
Set-RubrikSupportTunnel -EnableTunnel $false

 port isTunnelEnabled
 ---- ---------------
27208                
```

Trying to enable the tunnel when it's already enabled - this showcases the new user_error warning.

```
Set-RubrikSupportTunnel -EnableTunnel $true
WARNING: user_error
WARNING: Support tunnel is already enabled on node me
The remote server returned an error: (422) Unprocessable Entity.
At C:\Dropbox\Code\Rubrik\Rubrik\Private\Submit-Request.ps1:31 char:21
+                     throw $_.Exception
+                     ~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (:) [], WebException
    + FullyQualifiedErrorId : The remote server returned an error: (422) Unprocessable Entity.
```

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
