### PR TITLE
Bug fix for Tls12 and PowerShell 4.0.

### DIFF
--- a/Rubrik/Public/Connect-Rubrik.ps1
+++ b/Rubrik/Public/Connect-Rubrik.ps1
@@ -101,12 +101,12 @@ function Connect-Rubrik
           'Authorization' = "Basic $auth"
         }      
       }
-
-      Write-Verbose -Message 'Adding TLS 1.2'
+      
       #Force TLS 1.2
       try{
-        if([Net.ServicePointManager]::SecurityProtocol -notcontains 'Tls12'){
-          [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+        if([Net.ServicePointManager]::SecurityProtocol -notlike '*Tls12*'){
+          Write-Verbose -Message 'Adding TLS 1.2'
+          [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol).tostring() +', Tls12'
         }
       }
       catch 


### PR DESCRIPTION
# Description

Altered addition method for Tls12 to support PowerShell 4.0 syntax. Now instead of adding to an array, the code will append `,Tls12` to the end of the network security string.

## Related Issue

Issue #156 

## Motivation and Context

Allows the addition of TLS1.2 to network security methods for PowerShell 4.0

## How Has This Been Tested?
Tested by several users connecting to SE-3 (Rubrik SE lab) which has TLS1.0 disabled.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
