### PR TITLE
Allow versions in Get-RubrikAPIData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,12 +31,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * [GitHub Pull Request Template](https://github.com/rubrikinc/PowerShell-Module/pull/135).
 * [GitHub Issue Template](https://github.com/rubrikinc/PowerShell-Module/commit/ca0a7fc1864c42162236b4e68af6f44d07f0a164).
 * [Invoke-RubrikRESTCall](https://github.com/rubrikinc/PowerShell-Module/pull/118).
+* TLS v1.2 support triggered during the usage of `Connect-Rubrik`.
 
 ### Changed
 
 * Track `user_error` responses in the `Submit-Request` private function
 * The `Get-RubrikSnapshot` function supports HyperV VMs.
+* Updated API Data for 4.1 against `Get-RubrikReport` and `Get-RubrikReportData`.
+* Modified `Get-RubrikAPIData` to use RCDM versions instead of API versions.
 
 ### Deprecated
 
 * Dynamic documentation using ReadTheDocs and reStructuredText.
+* Removed old session endpoint data from `Connect-Rubrik` used by RCDM versions 1.x and 2.x.

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -1,837 +1,882 @@
 ﻿<#
     Helper function to retrieve API data from Rubrik
 #>
-function Get-RubrikAPIData($endpoint)
-{
-  $api = @{
-    Example                      = @{
-      v1 = @{
-        Description = 'Details about the API endpoint'
-        URI         = 'The URI expressed as /api/v#/endpoint'
-        Method      = 'Method to use against the endpoint'
-        Body        = 'Parameters to use in the body'
-        Query       = 'Parameters to use in the URI query'
-        Result      = 'If the result content is stored in a higher level key, express it here to be unwrapped in the return'
-        Filter      = 'If the result content needs to be filtered based on key names, express them here'
-        Success     = 'The expected HTTP status code for a successful call'
-      }
-    }
-    'Connect-Rubrik'             = @{
-      'v1.1' = @{
-        Description = 'Create a new login session'
-        URI         = '/api/v1/session'
-        Method      = 'Post'
-        Body        = ''
-        Query       = ''
-        Result      = ''
-        Filter      = ''
-        Success     = '200'
-      }
-      'v1.0' = @{
-        Description = 'Create a new login session'
-        URI         = '/api/v1/login'
-        Method      = 'Post'
-        Body        = @('username', 'password')
-        Query       = ''
-        Result      = ''
-        Filter      = ''
-        Success     = '200'
-      }
-    }
-    'Disconnect-Rubrik'          = @{
-      v1 = @{
-        Description = 'Closes a user session and invalidates the session token'
-        URI         = '/api/v1/session/{id}'
-        Method      = 'Delete'
-        Body        = ''
-        Query       = ''
-        Result      = ''
-        Filter      = ''
-        Success     = '204'
-      }
-    }
-    'Export-RubrikDatabase'      = @{
-      v1 = @{
-        Description = 'Export MSSQL Database from Rubrik to Destination Instance.'
-        URI         = '/api/v1/mssql/db/{id}/export'
-        Method      = 'Post'
-        Body        = @{
-          targetInstanceId   = 'targetInstanceId'
-          targetDatabaseName = 'targetDatabaseName'
-          recoveryPoint      = @{
-            timestampMs = 'timestampMs'
-          }
-          finishRecovery     = 'finishRecovery'
-          maxDataStreams     = 'maxDataStreams'
-        }
-        Query       = ''
-        Result      = ''
-        Filter      = ''
-        Success     = '202'
-      }
-    }
-    'Export-RubrikReport'        = @{
-      v1 = @{
-        Description = 'Get the link to a CSV file for a report.'
-        URI         = '/api/internal/report/{id}/download_csv'
-        Method      = 'Get'
-        Body        = ''
-        Query       = @{
-          timezone_offset = 'timezone_offset'
-        }
-        Result      = 'data'
-        Filter      = ''
-        Success     = '200'
-      }
-    }
-    'Get-RubrikAPIVersion'          = @{
-      v1 = @{
-        Description = 'Retrieves software version of the Rubrik cluster'
-        URI         = '/api/v1/cluster/{id}/api_version'
-        Method      = 'Get'
-        Body        = ''
-        Query       = ''
-        Result      = 'apiVersion'
-        Filter      = ''
-        Success     = '200'
-      }
-    }     
-    'Get-RubrikDatabase'         = @{
-      v1 = @{
-        Description = 'Returns a list of summary information for Microsoft SQL databases.'
-        URI         = '/api/v1/mssql/db'
-        Method      = 'Get'
-        Body        = ''
-        Query       = @{
-          instance_id             = 'instance_id'
-          effective_sla_domain_id = 'effective_sla_domain_id'
-          primary_cluster_id      = 'primary_cluster_id'
-          is_relic                = 'is_relic'
-        }
-        Result      = 'data'
-        Filter      = @{
-          'Name'   = 'name'
-          'SLA'    = 'effectiveSlaDomainName'
-          'Hostname' = 'rootProperties.rootName'
-          'Instance' = 'instanceName'
-        }
-        Success     = '200'
-      }
-    }
-    'Get-RubrikDatabaseFiles'         = @{
-      v1 = @{
-        Description = 'Returns a list of files for the database.'
-        URI         = '/api/internal/mssql/db/{id}/restore_files'
-        Method      = 'Get'
-        Body        = ''
-        Query       = @{
-          time = 'time'
-        }
-        Result      = 'data'
-        Filter      = ''
-        Success     = '200'
-      }
-    }
-    'Get-RubrikDatabaseMount'            = @{
-      v1 = @{
-        Description = 'Retrieve information for all live mounts for databases'
-        URI         = '/api/v1/mssql/db/mount'
-        Method      = 'Get'
-        Body        = ''
-        Query       = @{
-          source_database_id = 'source_database_id'
-          source_database_name = 'source_database_name'
-          target_instance_id = 'target_instance_id'
-          mounted_database_name = 'mounted_database_name'
-          offset = 'offset'
-          limit  = 'limit'
-        }
-        Result      = 'data'
-        Filter      = ''
-        Success     = '200'
-      }
-    }
-    'Get-RubrikFileset'          = @{
-      v1 = @{
-        Description = 'Retrieve summary information for each fileset. Optionally, filter the retrieved information.'
-        URI         = '/api/v1/fileset'
-        Method      = 'Get'
-        Body        = ''
-        Query       = @{
-          primary_cluster_id      = 'primary_cluster_id'
-          host_id                 = 'host_id'
-          is_relic                = 'is_relic'
-          effective_sla_domain_id = 'effective_sla_domain_id'
-          template_id             = 'template_id'
-          limit                   = 'limit'
-          offset                  = 'offset'
-          cached                  = 'cached'
-          name                    = 'name'
-          host_name               = 'host_name'
-        }
-        Result      = 'data'
-        Filter      = @{
-          'SLA' = 'effectiveSlaDomainName'
-        }
-        Success     = '200'
-      }
-    }
-    'Get-RubrikFilesetTemplate'  = @{
-      v1 = @{
-        Description = 'Retrieve summary information for all fileset templates, including: ID and name of the fileset template, fileset template creation timestamp, array of the included filepaths, array of the excluded filepaths.'
-        Function    = 'Get-RubrikFilesetTemplate'
-        URI         = '/api/v1/fileset_template'
-        Method      = 'Get'
-        Body        = ''
-        Query       = @{
-          primary_cluster_id    = 'primary_cluster_id'
-          operating_system_type = 'operating_system_type'
-          name                  = 'name'
-        }
-        Result      = 'data'
-        Filter      = ''
-        Success     = '200'
-      }
-    }    
-    'Get-RubrikHost'             = @{
-      v1 = @{
-        Description = 'Retrieve summary information for all hosts that are registered with a Rubrik cluster'
-        URI         = '/api/v1/host'
-        Method      = 'Get'
-        Body        = ''
-        Query       = @{
-          operating_system_type = 'operating_system_type'
-          primary_cluster_id    = 'primary_cluster_id'
-          hostname              = 'hostname'
-        }
-        Result      = 'data'
-        Filter      = ''
-        Success     = '200'
-      }
-    }
-    'Get-RubrikMount'            = @{
-      v1 = @{
-        Description = 'Retrieve information for all live mounts'
-        URI         = '/api/v1/vmware/vm/snapshot/mount'
-        Method      = 'Get'
-        Body        = ''
-        Query       = @{
-          vm_id  = 'vm_id'
-          offset = 'offset'
-          limit  = 'limit'
-        }
-        Result      = 'data'
-        Filter      = ''
-        Success     = '200'
-      }
-    }
-    'Get-RubrikReport'           = @{
-      v1 = @{
-        Description = 'Retrieve summary information for each report.'
-        URI         = '/api/internal/report'
-        Method      = 'Get'
-        Body        = ''
-        Query       = @{
-          report_type = 'report_type'
-          search_text = 'search_text'
-        }
-        Result      = 'data'
-        Filter      = ''
-        Success     = '200'
-      }
-    }
-    'Get-RubrikReportData'           = @{
-      v1 = @{
-        Description = 'Retrieve table data for a specific report'
-        URI         = '/api/internal/report/{id}/table'
-        Method      = 'Get'
-        Body        = ''
-        Query       = @{
-          search_value = 'search_value'
-          sla_domain_id = 'sla_domain_id'
-          task_type = 'task_type'
-          task_status = 'task_status'
-          object_type = 'object_type'
-          compliance_status = 'compliance_status'
-          cluster_location = 'cluster_location'
-        }
-        Result      = ''
-        Filter      = ''
-        Success     = '200'
-      }
-    }    
-    'Get-RubrikRequest'          = @{
-      v1 = @{
-        Description = 'Get details about an async request.'
-        URI         = '/api/v1/{type}/request/{id}'
-        Method      = 'Get'
-        Body        = ''
-        Query       = ''
-        Result      = ''
-        Filter      = ''
-        Success     = '200'
-      }
-    }
-    'Get-RubrikSLA'              = @{
-      v1 = @{
-        Description = 'Retrieve summary information for all SLA Domains'
-        URI         = '/api/v1/sla_domain'
-        Method      = 'Get'
-        Body        = 'Parameters to use in the body'
-        Query       = @{
-          primary_cluster_id = 'primary_cluster_id'
-        }
-        Result      = 'data'
-        Filter      = @{
-          'Name' = 'name'
-        }
-        Success     = '200'
-      }
-    }
-    'Get-RubrikSnapshot'         = @{
-      v1 = @{
-        Description = 'Retrieve information for all snapshots for a VM'
-        URI         = @{
-          Fileset = '/api/v1/fileset/{id}/snapshot'
-          MSSQL   = '/api/v1/mssql/db/{id}/snapshot'
-          VMware  = '/api/v1/vmware/vm/{id}/snapshot'
-          HyperV  = '/api/internal/hyperv/vm/{id}/snapshot'
-        }
-        Method      = 'Get'
-        Body        = ''
-        Query       = ''
-        Result      = 'data'
-        Filter      = @{
-          'CloudState'     = 'cloudState'
-          'OnDemandSnapshot' = 'isOnDemandSnapshot'
-        }
-        Success     = '200'
-      }
-    }
-    'Get-RubrikSoftwareVersion'          = @{
-      v1 = @{
-        Description = 'Retrieves software version of the Rubrik cluster'
-        URI         = '/api/v1/cluster/{id}/version'
-        Method      = 'Get'
-        Body        = ''
-        Query       = ''
-        Result      = 'version'
-        Filter      = ''
-        Success     = '200'
-      }
-    }
-    'Get-RubrikSQLInstance'         = @{
-      v1 = @{
-        Description = 'Returns a list of summary information for Microsoft SQL instances.'
-        URI         = '/api/v1/mssql/instance'
-        Method      = 'Get'
-        Body        = ''
-        Query       = @{
-          instance_id             = 'instance_id'
-        }
-        Result      = 'data'
-        Filter      = @{
-          'Name'   = 'name'
-          'SLA'    = 'configuredSlaDomainName'
-          'Hostname' = 'rootProperties.rootName'
-        }
-        Success     = '200'
-      }
-    }
-    'Get-RubrikSupportTunnel' = @{
-      v1 = @{
-        Description = 'To be used by Admin to check status of the support tunnel.'
-        URI         = '/api/internal/node/me/support_tunnel'
-        Method      = 'Get'
-        Body        = ''
-        Query       = ''
-        Result      = ''
-        Filter      = ''
-        Success     = '200'
-      }
-    }     
-    'Get-RubrikUnmanagedObject'  = @{
-      v1 = @{
-        Description = 'Get summary of all the objects with unmanaged snapshots'
-        URI         = '/api/internal/unmanaged_object'
-        Method      = 'Get'
-        Body        = ''
-        Query       = @{
-          search_value     = 'search_value'
-          unmanaged_status = 'unmanaged_status'
-          object_type      = 'object_type'
-        }
-        Result      = 'data'
-        Filter      = ''
-        Success     = '200'
-      }
-    }
-    'Get-RubrikVersion'          = @{
-      v1 = @{
-        Description = 'Retrieve public information about the Rubrik cluster'
-        URI         = '/api/v1/cluster/{id}'
-        Method      = 'Get'
-        Body        = ''
-        Query       = ''
-        Result      = ''
-        Filter      = ''
-        Success     = '200'
-      }
-    }
-    'Get-RubrikVM'               = @{
-      v1 = @{
-        Description = 'Get summary of all the VMs'
-        URI         = '/api/v1/vmware/vm'
-        Method      = 'Get'
-        Body        = ''
-        Query       = @{
-          is_relic                = 'is_relic'
-          name                    = 'name'
-          effective_sla_domain_id = 'effective_sla_domain_id'
-          sla_assignment          = 'sla_assignment'
-          primary_cluster_id      = 'primary_cluster_id'
-        }
-        Result      = 'data'
-        Filter      = @{
-          'Name' = 'name'
-          'SLA' = 'effectiveSlaDomainName'
-        }
-        Success     = '200'
-      }
-    }
-    'New-RubrikDatabaseMount'            = @{
-      v1 = @{
-        Description = 'Create a live mount request with given configuration'
-        URI         = '/api/v1/mssql/db/{id}/mount'
-        Method      = 'Post'
-        Body        = @{
-          targetInstanceId     = 'targetInstanceId'
-          mountedDatabaseName  = 'mountedDatabaseName'
-          recoveryPoint = @{
-              timestampMs = 'timestampMs'
-          }
-        }
-        Query       = ''
-        Result      = ''
-        Filter      = ''
-        Success     = '202'
-      }
-    }
-    'New-RubrikHost'             = @{
-      v1 = @{
-        Description = 'Register a host'
-        URI         = '/api/v1/host'
-        Method      = 'Post'
-        Body        = @{
-          hostname = 'hostname'
-          hasAgent = 'hasAgent'
-        }
-        Query       = ''
-        Result      = ''
-        Filter      = ''
-        Success     = '201'
-      }
-    }
-    'New-RubrikMount'            = @{
-      v1 = @{
-        Description = 'Create a live mount request with given configuration'
-        URI         = '/api/v1/vmware/vm/snapshot/{id}/mount'
-        Method      = 'Post'
-        Body        = @{
-          hostId               = 'hostId'
-          vmName               = 'vmName'
-          dataStoreName        = 'dataStoreName'
-          disableNetwork       = 'disableNetwork'
-          removeNetworkDevices = 'removeNetworkDevices'
-          powerOn              = 'powerOn'
-        }
-        Query       = ''
-        Result      = ''
-        Filter      = ''
-        Success     = '202'
-      }
-    }
-    'New-RubrikReport'            = @{
-      v1 = @{
-        Description = 'Create a new report by specifying one of the report templates'
-        URI         = '/api/internal/report'
-        Method      = 'Post'
-        Body        = @{
-          name               = 'name'
-          reportTemplate     = 'reportTemplate'
-        }
-        Query       = ''
-        Result      = ''
-        Filter      = ''
-        Success     = '201'
-      }
-    }    
-    'New-RubrikSLA'              = @{
-      v1 = @{
-        Description = 'Create a new SLA Domain on a Rubrik cluster by specifying Domain Rules and policies'
-        URI         = '/api/v1/sla_domain'
-        Method      = 'Post'
-        Body        = @{
-          name        = 'name'
-          frequencies = @{
-            timeUnit  = 'timeUnit'
-            frequency = 'frequency'
-            retention = 'retention'
-          }
-        }
-        Query       = ''
-        Result      = ''
-        Filter      = ''
-        Success     = '201'
-      }
-    }
-    'New-RubrikSnapshot'         = @{
-      v1 = @{
-        Description = 'Create an on-demand snapshot for the given object ID'
-        URI         = @{
-          Fileset = '/api/v1/fileset/{id}/snapshot'
-          MSSQL   = '/api/v1/mssql/db/{id}/snapshot'
-          VMware  = '/api/v1/vmware/vm/{id}/snapshot'
-        }
-        Method      = 'Post'
-        Body        = @{
-          forceFullSnapshot = 'forceFullSnapshot'
-          slaId = 'slaId'
-        }
-        Query       = ''
-        Result      = ''
-        Filter      = ''
-        Success     = '202'
-      }
-    }
-    'Protect-RubrikDatabase'     = @{
-      v1 = @{
-        Description = 'Update a Microsoft SQL database with the specified SLA Domain.'
-        URI         = '/api/v1/mssql/db/{id}'
-        Method      = 'Patch'
-        Body        = @{
-          logBackupFrequencyInSeconds = 'logBackupFrequencyInSeconds'
-          logRetentionHours           = 'logRetentionHours'
-          copyOnly                    = 'copyOnly'
-          maxDataStreams              = 'maxDataStreams'
-          configuredSlaDomainId       = 'configuredSlaDomainId'
-        }
-        Query       = ''
-        Result      = 'data'
-        Filter      = ''
-        Success     = '200'
-      }
-    }
-    'Protect-RubrikFileset'      = @{
-      v1 = @{
-        Description = 'Update a Fileset with the specified SLA Domain.'
-        URI         = '/api/v1/fileset/{id}'
-        Method      = 'Patch'
-        Body        = @{
-          configuredSlaDomainId = 'configuredSlaDomainId'
-        }
-        Query       = ''
-        Result      = 'data'
-        Filter      = ''
-        Success     = '200'
-      }
-    }
-    'Protect-RubrikTag'          = @{
-      v1 = @{
-        Description = 'Assign managed entities to the specified SLA Domain. The assignment event runs synchronously.'
-        URI         = '/api/internal/sla_domain/{id}/assign'
-        Method      = 'Post'
-        Body        = ''
-        Query       = ''
-        Result      = ''
-        Filter      = ''
-        Success     = '204'
-      }
-    }
-    'Protect-RubrikVM'           = @{
-      v1 = @{
-        Description = 'Update a VM with the specified SLA Domain.'
-        URI         = '/api/v1/vmware/vm/{id}'
-        Method      = 'Patch'
-        Body        = @{
-          configuredSlaDomainId = 'configuredSlaDomainId'
-        }
-        Query       = ''
-        Result      = ''
-        Filter      = ''
-        Success     = '200'
-      }
-    }
-    'Remove-RubrikDatabaseMount'         = @{
-      v1 = @{
-        Description = 'Create a request to delete a database live mount'
-        URI         = '/api/v1/mssql/db/mount/{id}'
-        Method      = 'Delete'
-        Body        = ''
-        Query       = @{
-          force = 'force'
-        }
-        Result      = ''
-        Filter      = ''
-        Success     = '202'
-      }
-    }
-    'Remove-RubrikFileset'       = @{
-      v1 = @{
-        Description = 'Delete a fileset by specifying the fileset ID'
-        URI         = '/api/v1/fileset/{id}'
-        Method      = 'Delete'
-        Body        = ''
-        Query       = ''
-        Result      = ''
-        Filter      = ''
-        Success     = '204'
-      }
-    }
-    'Remove-RubrikHost'          = @{
-      v1 = @{
-        Description = 'Delete host by specifying the host ID'
-        URI         = '/api/v1/host/{id}'
-        Method      = 'Delete'
-        Body        = ''
-        Query       = ''
-        Result      = ''
-        Filter      = ''
-        Success     = '204'
-      }
-    }
-    'Remove-RubrikMount'         = @{
-      v1 = @{
-        Description = 'Create a request to delete a live mount'
-        URI         = '/api/v1/vmware/vm/snapshot/mount/{id}'
-        Method      = 'Delete'
-        Body        = ''
-        Query       = @{
-          force = 'force'
-        }
-        Result      = ''
-        Filter      = ''
-        Success     = '202'
-      }
-    }
-    'Remove-RubrikReport'        = @{
-      v1 = @{
-        Description = 'Delete a specific report specified by reportId'
-        URI         = '/api/internal/report/{id}'
-        Method      = 'Delete'
-        Body        = ''
-        Query       = ''
-        Result      = ''
-        Filter      = ''
-        Success     = '204'
-      }
-    }
-    'Remove-RubrikSLA'           = @{
-      v1 = @{
-        Description = 'Delete an SLA Domain from a Rubrik cluster'
-        URI         = '/api/v1/sla_domain/{id}'
-        Method      = 'Delete'
-        Body        = ''
-        Query       = ''
-        Result      = ''
-        Filter      = ''
-        Success     = '204'
-      }
-    }
-    'Remove-RubrikUnmanagedObject' = @{
-      v1 = @{
-        Description = 'Bulk delete all unmanaged snapshots for the objects specified by objectId/objectType pairings.'
-        URI         = '/api/internal/unmanaged_object/snapshot/bulk_delete'
-        Method      = 'Post'
-        Body        = @{
-          objectDefinitions = @(
-            @{
-              objectId   = 'objectId'
-              objectType = 'objectType'
+function Get-RubrikAPIData($endpoint) {
+    $api = @{
+        Example                        = @{
+            '1.0' = @{
+                Description = 'Details about the API endpoint'
+                URI         = 'The URI expressed as /api/v#/endpoint'
+                Method      = 'Method to use against the endpoint'
+                Body        = 'Parameters to use in the body'
+                Query       = 'Parameters to use in the URI query'
+                Result      = 'If the result content is stored in a higher level key, express it here to be unwrapped in the return'
+                Filter      = 'If the result content needs to be filtered based on key names, express them here'
+                Success     = 'The expected HTTP status code for a successful call'
             }
-          )
         }
-        Query       = ''
-        Result      = ''
-        Filter      = ''
-        Success     = '200'
-      }
-    }
-    'Restore-RubrikDatabase' = @{
-      v1 = @{
-        Description = 'Export MSSQL Database from Rubrik to Destination Instance.'
-        URI         = '/api/v1/mssql/db/{id}/restore'
-        Method      = 'Post'
-        Body        = @{
-          recoveryPoint      = @{
-            timestampMs = 'timestampMs'
-          }
-          finishRecovery     = 'finishRecovery'
-          maxDataStreams     = 'maxDataStreams'
-        }
-        Query       = ''
-        Result      = ''
-        Filter      = ''
-        Success     = '202'
-      }
-    }
-    'Set-RubrikBlackout'         = @{
-      v1 = @{
-        Description = 'Whether to start or stop the global blackout window.'
-        URI         = '/api/internal/blackout_window'
-        Method      = 'Patch'
-        Body        = @{
-          isGlobalBlackoutActive = 'isGlobalBlackoutActive'
-        }
-        Query       = ''
-        Result      = ''
-        Filter      = ''
-        Success     = '200'
-      }
-    }
-    'Set-RubrikDatabase'         = @{
-      v1 = @{
-        Description = 'Updates Rubrik database settings.'
-        URI         = '/api/v1/mssql/db/{id}'
-        Method      = 'Patch'
-        Body        = @{
-          logBackupFrequencyInSeconds = "logBackupFrequencyInSeconds"
-          logRetentionHours = "logRetentionHours"
-          copyOnly = "copyOnly"
-          maxDataStreams = "maxDataStreams"
-          configuredSlaDomainId = "configuredSlaDomainId"   
-        }
-        Query       = ''
-        Result      = ''
-        Filter      = ''
-        Success     = '200'
-      }
-    }
-    'Set-RubrikMount'            = @{
-      v1 = @{
-        Description = 'Power given live-mounted vm on/off'
-        URI         = '/api/v1/vmware/vm/snapshot/mount/{id}'
-        Method      = 'Patch'
-        Body        = @{
-          powerStatus = 'powerStatus'
-        }
-        Query       = ''
-        Result      = ''
-        Filter      = ''
-        Success     = '200'
-      }
-    }
-    'Set-RubrikReport'            = @{
-      v1 = @{
-        Description = 'Update a specific report. The report''s name, chart parameters, filters and table can be updated. If successful, this will automatically trigger an async job to refresh the report content.'
-        URI         = '/api/internal/report/{id}'
-        Method      = 'Patch'
-        Body        = @{
-          name  = 'name'
-          filters = @{
-            slaDomain = 'slaDomain'
-            objects = 'objects'
-            objectType = 'objectType'
-            objectLocation = 'objectLocation'            
-            clusterLocation = 'clusterLocation'
-            taskType = 'taskType'
-            complianceStatus = 'complianceStatus'
-            dateConfig = @{
-              beforeDate = 'beforeDate'
-              afterDate = 'afterDate'
-              period = 'period'
+        'Connect-Rubrik'               = @{
+            '3.0' = @{
+                Description = 'Create a new login session'
+                URI         = '/api/v1/session'
+                Method      = 'Post'
+                Body        = ''
+                Query       = ''
+                Result      = ''
+                Filter      = ''
+                Success     = '200'
             }
-          }
-          chart0 = @{
-            id = 'id'
-            name = 'name'
-            chartType = 'chartType'
-            attribute = 'attribute'
-            measure = 'measure' 
-          }
-          chart1 = @{
-            id = 'id'
-            name = 'name'
-            chartType = 'chartType'
-            attribute = 'attribute'
-            measure = 'measure' 
-          }
-          table = @{
-            columns = 'columns'
-          }
         }
-        Query       = ''
-        Result      = ''
-        Filter      = ''
-        Success     = '200'
-      }
-    }
-    'Set-RubrikSQLInstance'         = @{
-      v1 = @{
-        Description = 'Updates Rubrik database settings.'
-        URI         = '/api/v1/mssql/instance/{id}'
-        Method      = 'Patch'
-        Body        = @{
-          logBackupFrequencyInSeconds = "logBackupFrequencyInSeconds"
-          logRetentionHours = "logRetentionHours"
-          copyOnly = "copyOnly"
-          maxDataStreams = "maxDataStreams"
-          configuredSlaDomainId = "configuredSlaDomainId"   
+        'Disconnect-Rubrik'            = @{
+            '1.0' = @{
+                Description = 'Closes a user session and invalidates the session token'
+                URI         = '/api/v1/session/{id}'
+                Method      = 'Delete'
+                Body        = ''
+                Query       = ''
+                Result      = ''
+                Filter      = ''
+                Success     = '204'
+            }
         }
-        Query       = ''
-        Result      = ''
-        Filter      = ''
-        Success     = '200'
-      }
-    }
-    'Set-RubrikSupportTunnel'         = @{
-      v1 = @{
-        Description = 'To be used by Admin to open or close a SSH tunnel for support.'
-        URI         = '/api/internal/node/me/support_tunnel'
-        Method      = 'Patch'
-        Body        = @{
-          isTunnelEnabled = "isTunnelEnabled"
-          inactivityTimeoutInSeconds = "inactivityTimeoutInSeconds"
+        'Export-RubrikDatabase'        = @{
+            '1.0' = @{
+                Description = 'Export MSSQL Database from Rubrik to Destination Instance.'
+                URI         = '/api/v1/mssql/db/{id}/export'
+                Method      = 'Post'
+                Body        = @{
+                    targetInstanceId   = 'targetInstanceId'
+                    targetDatabaseName = 'targetDatabaseName'
+                    recoveryPoint      = @{
+                        timestampMs = 'timestampMs'
+                    }
+                    finishRecovery     = 'finishRecovery'
+                    maxDataStreams     = 'maxDataStreams'
+                }
+                Query       = ''
+                Result      = ''
+                Filter      = ''
+                Success     = '202'
+            }
         }
-        Query       = ''
-        Result      = ''
-        Filter      = ''
-        Success     = '200'
-      }
-    }     
-    'Set-RubrikVM'               = @{
-      v1 = @{
-        Description = 'Update VM with specified properties'
-        URI         = '/api/v1/vmware/vm/{id}'
-        Method      = 'Patch'
-        Body        = @{
-          snapshotConsistencyMandate = 'snapshotConsistencyMandate'
-          maxNestedVsphereSnapshots  = 'maxNestedVsphereSnapshots'
-          isVmPaused                 = 'isVmPaused'
-          preBackupScript            = @{
-            scriptPath      = 'scriptPath'
-            timeoutMs       = 'timeoutMs'
-            failureHandling = 'failureHandling'
-          }
-          postSnapScript             = @{
-            scriptPath      = 'scriptPath'
-            timeoutMs       = 'timeoutMs'
-            failureHandling = 'failureHandling'
-          }
-          postBackupScript           = @{
-            scriptPath      = 'scriptPath'
-            timeoutMs       = 'timeoutMs'
-            failureHandling = 'failureHandling'
-          }
-          isArrayIntegrationEnabled  = 'isArrayIntegrationEnabled'
+        'Export-RubrikReport'          = @{
+            '1.0' = @{
+                Description = 'Get the link to a CSV file for a report.'
+                URI         = '/api/internal/report/{id}/download_csv'
+                Method      = 'Get'
+                Body        = ''
+                Query       = @{
+                    timezone_offset = 'timezone_offset'
+                }
+                Result      = 'data'
+                Filter      = ''
+                Success     = '200'
+            }
         }
-        Query       = ''
-        Result      = ''
-        Filter      = ''
-        Success     = '200'
-      }
-    }
-  } # End of API
+        'Get-RubrikAPIVersion'         = @{
+            '1.0' = @{
+                Description = 'Retrieves software version of the Rubrik cluster'
+                URI         = '/api/v1/cluster/{id}/api_version'
+                Method      = 'Get'
+                Body        = ''
+                Query       = ''
+                Result      = 'apiVersion'
+                Filter      = ''
+                Success     = '200'
+            }
+        }     
+        'Get-RubrikDatabase'           = @{
+            '1.0' = @{
+                Description = 'Returns a list of summary information for Microsoft SQL databases.'
+                URI         = '/api/v1/mssql/db'
+                Method      = 'Get'
+                Body        = ''
+                Query       = @{
+                    instance_id             = 'instance_id'
+                    effective_sla_domain_id = 'effective_sla_domain_id'
+                    primary_cluster_id      = 'primary_cluster_id'
+                    is_relic                = 'is_relic'
+                }
+                Result      = 'data'
+                Filter      = @{
+                    'Name'     = 'name'
+                    'SLA'      = 'effectiveSlaDomainName'
+                    'Hostname' = 'rootProperties.rootName'
+                    'Instance' = 'instanceName'
+                }
+                Success     = '200'
+            }
+        }
+        'Get-RubrikDatabaseFiles'      = @{
+            '1.0' = @{
+                Description = 'Returns a list of files for the database.'
+                URI         = '/api/internal/mssql/db/{id}/restore_files'
+                Method      = 'Get'
+                Body        = ''
+                Query       = @{
+                    time = 'time'
+                }
+                Result      = 'data'
+                Filter      = ''
+                Success     = '200'
+            }
+        }
+        'Get-RubrikDatabaseMount'      = @{
+            '1.0' = @{
+                Description = 'Retrieve information for all live mounts for databases'
+                URI         = '/api/v1/mssql/db/mount'
+                Method      = 'Get'
+                Body        = ''
+                Query       = @{
+                    source_database_id    = 'source_database_id'
+                    source_database_name  = 'source_database_name'
+                    target_instance_id    = 'target_instance_id'
+                    mounted_database_name = 'mounted_database_name'
+                    offset                = 'offset'
+                    limit                 = 'limit'
+                }
+                Result      = 'data'
+                Filter      = ''
+                Success     = '200'
+            }
+        }
+        'Get-RubrikFileset'            = @{
+            '1.0' = @{
+                Description = 'Retrieve summary information for each fileset. Optionally, filter the retrieved information.'
+                URI         = '/api/v1/fileset'
+                Method      = 'Get'
+                Body        = ''
+                Query       = @{
+                    primary_cluster_id      = 'primary_cluster_id'
+                    host_id                 = 'host_id'
+                    is_relic                = 'is_relic'
+                    effective_sla_domain_id = 'effective_sla_domain_id'
+                    template_id             = 'template_id'
+                    limit                   = 'limit'
+                    offset                  = 'offset'
+                    cached                  = 'cached'
+                    name                    = 'name'
+                    host_name               = 'host_name'
+                }
+                Result      = 'data'
+                Filter      = @{
+                    'SLA' = 'effectiveSlaDomainName'
+                }
+                Success     = '200'
+            }
+        }
+        'Get-RubrikFilesetTemplate'    = @{
+            '1.0' = @{
+                Description = 'Retrieve summary information for all fileset templates, including: ID and name of the fileset template, fileset template creation timestamp, array of the included filepaths, array of the excluded filepaths.'
+                Function    = 'Get-RubrikFilesetTemplate'
+                URI         = '/api/v1/fileset_template'
+                Method      = 'Get'
+                Body        = ''
+                Query       = @{
+                    primary_cluster_id    = 'primary_cluster_id'
+                    operating_system_type = 'operating_system_type'
+                    name                  = 'name'
+                }
+                Result      = 'data'
+                Filter      = ''
+                Success     = '200'
+            }
+        }    
+        'Get-RubrikHost'               = @{
+            '1.0' = @{
+                Description = 'Retrieve summary information for all hosts that are registered with a Rubrik cluster'
+                URI         = '/api/v1/host'
+                Method      = 'Get'
+                Body        = ''
+                Query       = @{
+                    operating_system_type = 'operating_system_type'
+                    primary_cluster_id    = 'primary_cluster_id'
+                    hostname              = 'hostname'
+                }
+                Result      = 'data'
+                Filter      = ''
+                Success     = '200'
+            }
+        }
+        'Get-RubrikMount'              = @{
+            '1.0' = @{
+                Description = 'Retrieve information for all live mounts'
+                URI         = '/api/v1/vmware/vm/snapshot/mount'
+                Method      = 'Get'
+                Body        = ''
+                Query       = @{
+                    vm_id  = 'vm_id'
+                    offset = 'offset'
+                    limit  = 'limit'
+                }
+                Result      = 'data'
+                Filter      = ''
+                Success     = '200'
+            }
+        }
+        'Get-RubrikReport'             = @{
+            '1.0' = @{
+                Description = 'Retrieve summary information for each report.'
+                URI         = '/api/internal/report'
+                Method      = 'Get'
+                Body        = ''
+                Query       = @{
+                    report_type = 'report_type'
+                    search_text = 'search_text'
+                }
+                Result      = 'data'
+                Filter      = ''
+                Success     = '200'
+            }  
+            '4.1' = @{
+                Description = 'Retrieve summary information for each report.'
+                URI         = '/api/internal/report'
+                Method      = 'Get'
+                Body        = ''
+                Query       = @{
+                    report_type = 'report_type'
+                    search_text = 'name'
+                }
+                Result      = 'data'
+                Filter      = ''
+                Success     = '200'
+            }
+        }
+        'Get-RubrikReportData'         = @{
+            '1.0' = @{
+                Description = 'Retrieve table data for a specific report'
+                URI         = '/api/internal/report/{id}/table'
+                Method      = 'Get'
+                Body        = ''
+                Query       = @{
+                    search_value      = 'search_value'
+                    sla_domain_id     = 'sla_domain_id'
+                    task_type         = 'task_type'
+                    task_status       = 'task_status'
+                    object_type       = 'object_type'
+                    compliance_status = 'compliance_status'
+                    cluster_location  = 'cluster_location'
+                }
+                Result      = ''
+                Filter      = ''
+                Success     = '200'
+            }
+            '4.1' = @{
+                Description = 'Retrieve table data for a specific report'
+                URI         = '/api/internal/report/{id}/table'
+                Method      = 'Post'
+                Body        = @{
+                    limit          = 'limit'
+                    sortBy         = 'sortBy'
+                    sortOrder      = 'sortOrder'
+                    search_value   = 'objectName'
+                    requestFilters = @{
+                        sla_domain_id     = 'slaDomain'
+                        task_type         = 'taskType'
+                        task_status       = 'taskStatus'
+                        object_type       = 'objectType'
+                        compliance_status = 'complianceStatus'
+                        cluster_location  = 'clusterLocation'
+                    }                    
+                }
+                Query       = ''
+                Result      = ''
+                Filter      = ''
+                Success     = '200'
+            }
+        }    
+        'Get-RubrikRequest'            = @{
+            '1.0' = @{
+                Description = 'Get details about an async request.'
+                URI         = '/api/v1/{type}/request/{id}'
+                Method      = 'Get'
+                Body        = ''
+                Query       = ''
+                Result      = ''
+                Filter      = ''
+                Success     = '200'
+            }
+        }
+        'Get-RubrikSLA'                = @{
+            '1.0' = @{
+                Description = 'Retrieve summary information for all SLA Domains'
+                URI         = '/api/v1/sla_domain'
+                Method      = 'Get'
+                Body        = 'Parameters to use in the body'
+                Query       = @{
+                    primary_cluster_id = 'primary_cluster_id'
+                }
+                Result      = 'data'
+                Filter      = @{
+                    'Name' = 'name'
+                }
+                Success     = '200'
+            }
+        }
+        'Get-RubrikSnapshot'           = @{
+            '1.0' = @{
+                Description = 'Retrieve information for all snapshots for a VM'
+                URI         = @{
+                    Fileset = '/api/v1/fileset/{id}/snapshot'
+                    MSSQL   = '/api/v1/mssql/db/{id}/snapshot'
+                    VMware  = '/api/v1/vmware/vm/{id}/snapshot'
+                    HyperV  = '/api/internal/hyperv/vm/{id}/snapshot'
+                }
+                Method      = 'Get'
+                Body        = ''
+                Query       = ''
+                Result      = 'data'
+                Filter      = @{
+                    'CloudState'       = 'cloudState'
+                    'OnDemandSnapshot' = 'isOnDemandSnapshot'
+                }
+                Success     = '200'
+            }
+        }
+        'Get-RubrikSoftwareVersion'    = @{
+            '1.0' = @{
+                Description = 'Retrieves software version of the Rubrik cluster'
+                URI         = '/api/v1/cluster/{id}/version'
+                Method      = 'Get'
+                Body        = ''
+                Query       = ''
+                Result      = 'version'
+                Filter      = ''
+                Success     = '200'
+            }
+        }
+        'Get-RubrikSQLInstance'        = @{
+            '1.0' = @{
+                Description = 'Returns a list of summary information for Microsoft SQL instances.'
+                URI         = '/api/v1/mssql/instance'
+                Method      = 'Get'
+                Body        = ''
+                Query       = @{
+                    instance_id = 'instance_id'
+                }
+                Result      = 'data'
+                Filter      = @{
+                    'Name'     = 'name'
+                    'SLA'      = 'configuredSlaDomainName'
+                    'Hostname' = 'rootProperties.rootName'
+                }
+                Success     = '200'
+            }
+        }
+        'Get-RubrikSupportTunnel'      = @{
+            '1.0' = @{
+                Description = 'To be used by Admin to check status of the support tunnel.'
+                URI         = '/api/internal/node/me/support_tunnel'
+                Method      = 'Get'
+                Body        = ''
+                Query       = ''
+                Result      = ''
+                Filter      = ''
+                Success     = '200'
+            }
+        }     
+        'Get-RubrikUnmanagedObject'    = @{
+            '1.0' = @{
+                Description = 'Get summary of all the objects with unmanaged snapshots'
+                URI         = '/api/internal/unmanaged_object'
+                Method      = 'Get'
+                Body        = ''
+                Query       = @{
+                    search_value     = 'search_value'
+                    unmanaged_status = 'unmanaged_status'
+                    object_type      = 'object_type'
+                }
+                Result      = 'data'
+                Filter      = ''
+                Success     = '200'
+            }
+        }
+        'Get-RubrikVersion'            = @{
+            '1.0' = @{
+                Description = 'Retrieve public information about the Rubrik cluster'
+                URI         = '/api/v1/cluster/{id}'
+                Method      = 'Get'
+                Body        = ''
+                Query       = ''
+                Result      = ''
+                Filter      = ''
+                Success     = '200'
+            }
+        }
+        'Get-RubrikVM'                 = @{
+            '1.0' = @{
+                Description = 'Get summary of all the VMs'
+                URI         = '/api/v1/vmware/vm'
+                Method      = 'Get'
+                Body        = ''
+                Query       = @{
+                    is_relic                = 'is_relic'
+                    name                    = 'name'
+                    effective_sla_domain_id = 'effective_sla_domain_id'
+                    sla_assignment          = 'sla_assignment'
+                    primary_cluster_id      = 'primary_cluster_id'
+                }
+                Result      = 'data'
+                Filter      = @{
+                    'Name' = 'name'
+                    'SLA'  = 'effectiveSlaDomainName'
+                }
+                Success     = '200'
+            }
+        }
+        'New-RubrikDatabaseMount'      = @{
+            '1.0' = @{
+                Description = 'Create a live mount request with given configuration'
+                URI         = '/api/v1/mssql/db/{id}/mount'
+                Method      = 'Post'
+                Body        = @{
+                    targetInstanceId    = 'targetInstanceId'
+                    mountedDatabaseName = 'mountedDatabaseName'
+                    recoveryPoint       = @{
+                        timestampMs = 'timestampMs'
+                    }
+                }
+                Query       = ''
+                Result      = ''
+                Filter      = ''
+                Success     = '202'
+            }
+        }
+        'New-RubrikHost'               = @{
+            '1.0' = @{
+                Description = 'Register a host'
+                URI         = '/api/v1/host'
+                Method      = 'Post'
+                Body        = @{
+                    hostname = 'hostname'
+                    hasAgent = 'hasAgent'
+                }
+                Query       = ''
+                Result      = ''
+                Filter      = ''
+                Success     = '201'
+            }
+        }
+        'New-RubrikMount'              = @{
+            '1.0' = @{
+                Description = 'Create a live mount request with given configuration'
+                URI         = '/api/v1/vmware/vm/snapshot/{id}/mount'
+                Method      = 'Post'
+                Body        = @{
+                    hostId               = 'hostId'
+                    vmName               = 'vmName'
+                    dataStoreName        = 'dataStoreName'
+                    disableNetwork       = 'disableNetwork'
+                    removeNetworkDevices = 'removeNetworkDevices'
+                    powerOn              = 'powerOn'
+                }
+                Query       = ''
+                Result      = ''
+                Filter      = ''
+                Success     = '202'
+            }
+        }
+        'New-RubrikReport'             = @{
+            '1.0' = @{
+                Description = 'Create a new report by specifying one of the report templates'
+                URI         = '/api/internal/report'
+                Method      = 'Post'
+                Body        = @{
+                    name           = 'name'
+                    reportTemplate = 'reportTemplate'
+                }
+                Query       = ''
+                Result      = ''
+                Filter      = ''
+                Success     = '201'
+            }
+        }    
+        'New-RubrikSLA'                = @{
+            '1.0' = @{
+                Description = 'Create a new SLA Domain on a Rubrik cluster by specifying Domain Rules and policies'
+                URI         = '/api/v1/sla_domain'
+                Method      = 'Post'
+                Body        = @{
+                    name        = 'name'
+                    frequencies = @{
+                        timeUnit  = 'timeUnit'
+                        frequency = 'frequency'
+                        retention = 'retention'
+                    }
+                }
+                Query       = ''
+                Result      = ''
+                Filter      = ''
+                Success     = '201'
+            }
+        }
+        'New-RubrikSnapshot'           = @{
+            '1.0' = @{
+                Description = 'Create an on-demand snapshot for the given object ID'
+                URI         = @{
+                    Fileset = '/api/v1/fileset/{id}/snapshot'
+                    MSSQL   = '/api/v1/mssql/db/{id}/snapshot'
+                    VMware  = '/api/v1/vmware/vm/{id}/snapshot'
+                }
+                Method      = 'Post'
+                Body        = @{
+                    forceFullSnapshot = 'forceFullSnapshot'
+                    slaId             = 'slaId'
+                }
+                Query       = ''
+                Result      = ''
+                Filter      = ''
+                Success     = '202'
+            }
+        }
+        'Protect-RubrikDatabase'       = @{
+            '1.0' = @{
+                Description = 'Update a Microsoft SQL database with the specified SLA Domain.'
+                URI         = '/api/v1/mssql/db/{id}'
+                Method      = 'Patch'
+                Body        = @{
+                    logBackupFrequencyInSeconds = 'logBackupFrequencyInSeconds'
+                    logRetentionHours           = 'logRetentionHours'
+                    copyOnly                    = 'copyOnly'
+                    maxDataStreams              = 'maxDataStreams'
+                    configuredSlaDomainId       = 'configuredSlaDomainId'
+                }
+                Query       = ''
+                Result      = 'data'
+                Filter      = ''
+                Success     = '200'
+            }
+        }
+        'Protect-RubrikFileset'        = @{
+            '1.0' = @{
+                Description = 'Update a Fileset with the specified SLA Domain.'
+                URI         = '/api/v1/fileset/{id}'
+                Method      = 'Patch'
+                Body        = @{
+                    configuredSlaDomainId = 'configuredSlaDomainId'
+                }
+                Query       = ''
+                Result      = 'data'
+                Filter      = ''
+                Success     = '200'
+            }
+        }
+        'Protect-RubrikTag'            = @{
+            '1.0' = @{
+                Description = 'Assign managed entities to the specified SLA Domain. The assignment event runs synchronously.'
+                URI         = '/api/internal/sla_domain/{id}/assign'
+                Method      = 'Post'
+                Body        = ''
+                Query       = ''
+                Result      = ''
+                Filter      = ''
+                Success     = '204'
+            }
+        }
+        'Protect-RubrikVM'             = @{
+            '1.0' = @{
+                Description = 'Update a VM with the specified SLA Domain.'
+                URI         = '/api/v1/vmware/vm/{id}'
+                Method      = 'Patch'
+                Body        = @{
+                    configuredSlaDomainId = 'configuredSlaDomainId'
+                }
+                Query       = ''
+                Result      = ''
+                Filter      = ''
+                Success     = '200'
+            }
+        }
+        'Remove-RubrikDatabaseMount'   = @{
+            '1.0' = @{
+                Description = 'Create a request to delete a database live mount'
+                URI         = '/api/v1/mssql/db/mount/{id}'
+                Method      = 'Delete'
+                Body        = ''
+                Query       = @{
+                    force = 'force'
+                }
+                Result      = ''
+                Filter      = ''
+                Success     = '202'
+            }
+        }
+        'Remove-RubrikFileset'         = @{
+            '1.0' = @{
+                Description = 'Delete a fileset by specifying the fileset ID'
+                URI         = '/api/v1/fileset/{id}'
+                Method      = 'Delete'
+                Body        = ''
+                Query       = ''
+                Result      = ''
+                Filter      = ''
+                Success     = '204'
+            }
+        }
+        'Remove-RubrikHost'            = @{
+            '1.0' = @{
+                Description = 'Delete host by specifying the host ID'
+                URI         = '/api/v1/host/{id}'
+                Method      = 'Delete'
+                Body        = ''
+                Query       = ''
+                Result      = ''
+                Filter      = ''
+                Success     = '204'
+            }
+        }
+        'Remove-RubrikMount'           = @{
+            '1.0' = @{
+                Description = 'Create a request to delete a live mount'
+                URI         = '/api/v1/vmware/vm/snapshot/mount/{id}'
+                Method      = 'Delete'
+                Body        = ''
+                Query       = @{
+                    force = 'force'
+                }
+                Result      = ''
+                Filter      = ''
+                Success     = '202'
+            }
+        }
+        'Remove-RubrikReport'          = @{
+            '1.0' = @{
+                Description = 'Delete a specific report specified by reportId'
+                URI         = '/api/internal/report/{id}'
+                Method      = 'Delete'
+                Body        = ''
+                Query       = ''
+                Result      = ''
+                Filter      = ''
+                Success     = '204'
+            }
+        }
+        'Remove-RubrikSLA'             = @{
+            '1.0' = @{
+                Description = 'Delete an SLA Domain from a Rubrik cluster'
+                URI         = '/api/v1/sla_domain/{id}'
+                Method      = 'Delete'
+                Body        = ''
+                Query       = ''
+                Result      = ''
+                Filter      = ''
+                Success     = '204'
+            }
+        }
+        'Remove-RubrikUnmanagedObject' = @{
+            '1.0' = @{
+                Description = 'Bulk delete all unmanaged snapshots for the objects specified by objectId/objectType pairings.'
+                URI         = '/api/internal/unmanaged_object/snapshot/bulk_delete'
+                Method      = 'Post'
+                Body        = @{
+                    objectDefinitions = @(
+                        @{
+                            objectId   = 'objectId'
+                            objectType = 'objectType'
+                        }
+                    )
+                }
+                Query       = ''
+                Result      = ''
+                Filter      = ''
+                Success     = '200'
+            }
+        }
+        'Restore-RubrikDatabase'       = @{
+            '1.0' = @{
+                Description = 'Export MSSQL Database from Rubrik to Destination Instance.'
+                URI         = '/api/v1/mssql/db/{id}/restore'
+                Method      = 'Post'
+                Body        = @{
+                    recoveryPoint  = @{
+                        timestampMs = 'timestampMs'
+                    }
+                    finishRecovery = 'finishRecovery'
+                    maxDataStreams = 'maxDataStreams'
+                }
+                Query       = ''
+                Result      = ''
+                Filter      = ''
+                Success     = '202'
+            }
+        }
+        'Set-RubrikBlackout'           = @{
+            '1.0' = @{
+                Description = 'Whether to start or stop the global blackout window.'
+                URI         = '/api/internal/blackout_window'
+                Method      = 'Patch'
+                Body        = @{
+                    isGlobalBlackoutActive = 'isGlobalBlackoutActive'
+                }
+                Query       = ''
+                Result      = ''
+                Filter      = ''
+                Success     = '200'
+            }
+        }
+        'Set-RubrikDatabase'           = @{
+            '1.0' = @{
+                Description = 'Updates Rubrik database settings.'
+                URI         = '/api/v1/mssql/db/{id}'
+                Method      = 'Patch'
+                Body        = @{
+                    logBackupFrequencyInSeconds = "logBackupFrequencyInSeconds"
+                    logRetentionHours           = "logRetentionHours"
+                    copyOnly                    = "copyOnly"
+                    maxDataStreams              = "maxDataStreams"
+                    configuredSlaDomainId       = "configuredSlaDomainId"   
+                }
+                Query       = ''
+                Result      = ''
+                Filter      = ''
+                Success     = '200'
+            }
+        }
+        'Set-RubrikMount'              = @{
+            '1.0' = @{
+                Description = 'Power given live-mounted vm on/off'
+                URI         = '/api/v1/vmware/vm/snapshot/mount/{id}'
+                Method      = 'Patch'
+                Body        = @{
+                    powerStatus = 'powerStatus'
+                }
+                Query       = ''
+                Result      = ''
+                Filter      = ''
+                Success     = '200'
+            }
+        }
+        'Set-RubrikReport'             = @{
+            '1.0' = @{
+                Description = 'Update a specific report. The report''s name, chart parameters, filters and table can be updated. If successful, this will automatically trigger an async job to refresh the report content.'
+                URI         = '/api/internal/report/{id}'
+                Method      = 'Patch'
+                Body        = @{
+                    name    = 'name'
+                    filters = @{
+                        slaDomain        = 'slaDomain'
+                        objects          = 'objects'
+                        objectType       = 'objectType'
+                        objectLocation   = 'objectLocation'            
+                        clusterLocation  = 'clusterLocation'
+                        taskType         = 'taskType'
+                        complianceStatus = 'complianceStatus'
+                        dateConfig       = @{
+                            beforeDate = 'beforeDate'
+                            afterDate  = 'afterDate'
+                            period     = 'period'
+                        }
+                    }
+                    chart0  = @{
+                        id        = 'id'
+                        name      = 'name'
+                        chartType = 'chartType'
+                        attribute = 'attribute'
+                        measure   = 'measure' 
+                    }
+                    chart1  = @{
+                        id        = 'id'
+                        name      = 'name'
+                        chartType = 'chartType'
+                        attribute = 'attribute'
+                        measure   = 'measure' 
+                    }
+                    table   = @{
+                        columns = 'columns'
+                    }
+                }
+                Query       = ''
+                Result      = ''
+                Filter      = ''
+                Success     = '200'
+            }
+        }
+        'Set-RubrikSQLInstance'        = @{
+            '1.0' = @{
+                Description = 'Updates Rubrik database settings.'
+                URI         = '/api/v1/mssql/instance/{id}'
+                Method      = 'Patch'
+                Body        = @{
+                    logBackupFrequencyInSeconds = "logBackupFrequencyInSeconds"
+                    logRetentionHours           = "logRetentionHours"
+                    copyOnly                    = "copyOnly"
+                    maxDataStreams              = "maxDataStreams"
+                    configuredSlaDomainId       = "configuredSlaDomainId"   
+                }
+                Query       = ''
+                Result      = ''
+                Filter      = ''
+                Success     = '200'
+            }
+        }
+        'Set-RubrikSupportTunnel'      = @{
+            '1.0' = @{
+                Description = 'To be used by Admin to open or close a SSH tunnel for support.'
+                URI         = '/api/internal/node/me/support_tunnel'
+                Method      = 'Patch'
+                Body        = @{
+                    isTunnelEnabled            = "isTunnelEnabled"
+                    inactivityTimeoutInSeconds = "inactivityTimeoutInSeconds"
+                }
+                Query       = ''
+                Result      = ''
+                Filter      = ''
+                Success     = '200'
+            }
+        }     
+        'Set-RubrikVM'                 = @{
+            '1.0' = @{
+                Description = 'Update VM with specified properties'
+                URI         = '/api/v1/vmware/vm/{id}'
+                Method      = 'Patch'
+                Body        = @{
+                    snapshotConsistencyMandate = 'snapshotConsistencyMandate'
+                    maxNestedVsphereSnapshots  = 'maxNestedVsphereSnapshots'
+                    isVmPaused                 = 'isVmPaused'
+                    preBackupScript            = @{
+                        scriptPath      = 'scriptPath'
+                        timeoutMs       = 'timeoutMs'
+                        failureHandling = 'failureHandling'
+                    }
+                    postSnapScript             = @{
+                        scriptPath      = 'scriptPath'
+                        timeoutMs       = 'timeoutMs'
+                        failureHandling = 'failureHandling'
+                    }
+                    postBackupScript           = @{
+                        scriptPath      = 'scriptPath'
+                        timeoutMs       = 'timeoutMs'
+                        failureHandling = 'failureHandling'
+                    }
+                    isArrayIntegrationEnabled  = 'isArrayIntegrationEnabled'
+                }
+                Query       = ''
+                Result      = ''
+                Filter      = ''
+                Success     = '200'
+            }
+        }
+    } # End of API
 
-  return $api.$endpoint
+    # Determine which version of RCDM is running
+    # Note: Disregard for Software and API version; these do not require authentication
+    if ($endpoint -eq 'Get-RubrikSoftwareVersion' -or $endpoint -eq 'Get-RubrikAPIVersion') {$key = '1.0'}
+
+    else {
+        # Take the first three values (major.minor) and convert to a float  
+        # If there is no version yet, we're probably connecting to the cluster for the first time (Connect-Rubrik)
+        if (!$global:RubrikConnection.version) {
+            $ver = [float](Get-RubrikSoftwareVersion -Server $Server).substring(0, 3)
+        }
+        # If there is a stored version, we'll use that to avoid more traffic to the cluster
+        else {
+            $ver = [float]$global:RubrikConnection.version.substring(0, 3)
+        }
+        # Parse through the keys to find a match (less or equal), pick the last one in the case of an array of values
+        # Example: We're using RCDM 4.0 and an endpoint has details for 1.0 and 4.0. Both are less/equal to 4.0. We'll want the last value (4.0).
+        # Example: We're using RCDM 4.0 and an endpoint has details for 1.0 and 4.1. 4.1 is not less/equal to 4.0, as such, we'll want the only matching value (1.0).
+        $key = $api.$endpoint.Keys | Sort-Object | Where-Object {$_ -le $ver} | Select-Object -Last 1
+    } 
+
+    return $api.$endpoint.$key
 } # End of function

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -878,5 +878,6 @@ function Get-RubrikAPIData($endpoint) {
         $key = $api.$endpoint.Keys | Sort-Object | Where-Object {$_ -le $ver} | Select-Object -Last 1
     } 
 
+    Write-Verbose -Message "Selected $key API Data for $endpoint"
     return $api.$endpoint.$key
 } # End of function

--- a/Rubrik/Public/Disconnect-Rubrik.ps1
+++ b/Rubrik/Public/Disconnect-Rubrik.ps1
@@ -56,7 +56,7 @@ function Disconnect-Rubrik
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Export-RubrikDatabase.ps1
+++ b/Rubrik/Public/Export-RubrikDatabase.ps1
@@ -78,7 +78,7 @@ function Export-RubrikDatabase
 
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
 

--- a/Rubrik/Public/Export-RubrikReport.ps1
+++ b/Rubrik/Public/Export-RubrikReport.ps1
@@ -54,7 +54,7 @@ function Export-RubrikReport
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Get-RubrikAPIVersion.ps1
+++ b/Rubrik/Public/Get-RubrikAPIVersion.ps1
@@ -44,7 +44,7 @@ function Get-RubrikAPIVersion
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Get-RubrikDatabase.ps1
+++ b/Rubrik/Public/Get-RubrikDatabase.ps1
@@ -83,7 +83,7 @@ function Get-RubrikDatabase
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
 

--- a/Rubrik/Public/Get-RubrikDatabaseFiles.ps1
+++ b/Rubrik/Public/Get-RubrikDatabaseFiles.ps1
@@ -66,7 +66,7 @@ function Get-RubrikDatabaseFiles
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Get-RubrikDatabaseMount.ps1
+++ b/Rubrik/Public/Get-RubrikDatabaseMount.ps1
@@ -76,7 +76,7 @@ function Get-RubrikDatabaseMount
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Get-RubrikFileset.ps1
+++ b/Rubrik/Public/Get-RubrikFileset.ps1
@@ -84,7 +84,7 @@ function Get-RubrikFileset
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Get-RubrikFilesetTemplate.ps1
+++ b/Rubrik/Public/Get-RubrikFilesetTemplate.ps1
@@ -65,7 +65,7 @@ function Get-RubrikFilesetTemplate
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Get-RubrikHost.ps1
+++ b/Rubrik/Public/Get-RubrikHost.ps1
@@ -67,7 +67,7 @@ function Get-RubrikHost
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Get-RubrikMount.ps1
+++ b/Rubrik/Public/Get-RubrikMount.ps1
@@ -65,7 +65,7 @@ function Get-RubrikMount
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Get-RubrikReport.ps1
+++ b/Rubrik/Public/Get-RubrikReport.ps1
@@ -61,7 +61,7 @@ function Get-RubrikReport
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Get-RubrikReportData.ps1
+++ b/Rubrik/Public/Get-RubrikReportData.ps1
@@ -66,7 +66,7 @@ function Get-RubrikReportData
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Get-RubrikRequest.ps1
+++ b/Rubrik/Public/Get-RubrikRequest.ps1
@@ -51,7 +51,7 @@ function Get-RubrikRequest
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Get-RubrikSLA.ps1
+++ b/Rubrik/Public/Get-RubrikSLA.ps1
@@ -57,7 +57,7 @@ function Get-RubrikSLA
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Get-RubrikSQLInstance.ps1
+++ b/Rubrik/Public/Get-RubrikSQLInstance.ps1
@@ -70,7 +70,7 @@ function Get-RubrikSQLInstance
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Get-RubrikSnapshot.ps1
+++ b/Rubrik/Public/Get-RubrikSnapshot.ps1
@@ -67,7 +67,7 @@ function Get-RubrikSnapshot
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Get-RubrikSoftwareVersion.ps1
+++ b/Rubrik/Public/Get-RubrikSoftwareVersion.ps1
@@ -44,7 +44,7 @@ function Get-RubrikSoftwareVersion
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Get-RubrikSupportTunnel.ps1
+++ b/Rubrik/Public/Get-RubrikSupportTunnel.ps1
@@ -44,7 +44,7 @@ function Get-RubrikSupportTunnel
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Get-RubrikUnmanagedObject.ps1
+++ b/Rubrik/Public/Get-RubrikUnmanagedObject.ps1
@@ -60,7 +60,7 @@ function Get-RubrikUnmanagedObject
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Get-RubrikVM.ps1
+++ b/Rubrik/Public/Get-RubrikVM.ps1
@@ -72,7 +72,7 @@ function Get-RubrikVM
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Get-RubrikVersion.ps1
+++ b/Rubrik/Public/Get-RubrikVersion.ps1
@@ -46,7 +46,7 @@ function Get-RubrikVersion
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/New-RubrikDatabaseMount.ps1
+++ b/Rubrik/Public/New-RubrikDatabaseMount.ps1
@@ -69,7 +69,7 @@ function New-RubrikDatabaseMount
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/New-RubrikHost.ps1
+++ b/Rubrik/Public/New-RubrikHost.ps1
@@ -54,7 +54,7 @@ function New-RubrikHost
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/New-RubrikMount.ps1
+++ b/Rubrik/Public/New-RubrikMount.ps1
@@ -72,7 +72,7 @@ function New-RubrikMount
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/New-RubrikReport.ps1
+++ b/Rubrik/Public/New-RubrikReport.ps1
@@ -50,7 +50,7 @@ function New-RubrikReport
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/New-RubrikSLA.ps1
+++ b/Rubrik/Public/New-RubrikSLA.ps1
@@ -72,7 +72,7 @@ function New-RubrikSLA
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/New-RubrikSnapshot.ps1
+++ b/Rubrik/Public/New-RubrikSnapshot.ps1
@@ -68,7 +68,7 @@ function New-RubrikSnapshot
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Protect-RubrikDatabase.ps1
+++ b/Rubrik/Public/Protect-RubrikDatabase.ps1
@@ -66,7 +66,7 @@ function Protect-RubrikDatabase
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Protect-RubrikFileset.ps1
+++ b/Rubrik/Public/Protect-RubrikFileset.ps1
@@ -63,7 +63,7 @@ function Protect-RubrikFileset
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Protect-RubrikTag.ps1
+++ b/Rubrik/Public/Protect-RubrikTag.ps1
@@ -75,7 +75,7 @@ function Protect-RubrikTag
 
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
 

--- a/Rubrik/Public/Protect-RubrikVM.ps1
+++ b/Rubrik/Public/Protect-RubrikVM.ps1
@@ -67,7 +67,7 @@ function Protect-RubrikVM
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Remove-RubrikDatabaseMount.ps1
+++ b/Rubrik/Public/Remove-RubrikDatabaseMount.ps1
@@ -56,7 +56,7 @@ function Remove-RubrikDatabaseMount
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Remove-RubrikFileset.ps1
+++ b/Rubrik/Public/Remove-RubrikFileset.ps1
@@ -50,7 +50,7 @@ function Remove-RubrikFileset
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Remove-RubrikHost.ps1
+++ b/Rubrik/Public/Remove-RubrikHost.ps1
@@ -50,7 +50,7 @@ function Remove-RubrikHost
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Remove-RubrikMount.ps1
+++ b/Rubrik/Public/Remove-RubrikMount.ps1
@@ -56,7 +56,7 @@ function Remove-RubrikMount
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Remove-RubrikReport.ps1
+++ b/Rubrik/Public/Remove-RubrikReport.ps1
@@ -54,7 +54,7 @@ function Remove-RubrikReport
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Remove-RubrikSLA.ps1
+++ b/Rubrik/Public/Remove-RubrikSLA.ps1
@@ -47,7 +47,7 @@ function Remove-RubrikSLA
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Remove-RubrikUnmanagedObject.ps1
+++ b/Rubrik/Public/Remove-RubrikUnmanagedObject.ps1
@@ -60,7 +60,7 @@ function Remove-RubrikUnmanagedObject
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Restore-RubrikDatabase.ps1
+++ b/Rubrik/Public/Restore-RubrikDatabase.ps1
@@ -67,7 +67,7 @@ function Restore-RubrikDatabase
 
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
 

--- a/Rubrik/Public/Set-RubrikBlackout.ps1
+++ b/Rubrik/Public/Set-RubrikBlackout.ps1
@@ -45,7 +45,7 @@ function Set-RubrikBlackout
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Set-RubrikDatabase.ps1
+++ b/Rubrik/Public/Set-RubrikDatabase.ps1
@@ -70,7 +70,7 @@ function Set-RubrikDatabase
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Set-RubrikMount.ps1
+++ b/Rubrik/Public/Set-RubrikMount.ps1
@@ -53,7 +53,7 @@ function Set-RubrikMount
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Set-RubrikSQLInstance.ps1
+++ b/Rubrik/Public/Set-RubrikSQLInstance.ps1
@@ -60,7 +60,7 @@ function Set-RubrikSQLInstance
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
 

--- a/Rubrik/Public/Set-RubrikSupportTunnel.ps1
+++ b/Rubrik/Public/Set-RubrikSupportTunnel.ps1
@@ -59,7 +59,7 @@ function Set-RubrikSupportTunnel
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/Rubrik/Public/Set-RubrikVM.ps1
+++ b/Rubrik/Public/Set-RubrikVM.ps1
@@ -65,7 +65,7 @@ function Set-RubrikVM
         
         # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
         Write-Verbose -Message "Gather API Data for $function"
-        $resources = (Get-RubrikAPIData -endpoint $function).$api
+        $resources = Get-RubrikAPIData -endpoint $function
         Write-Verbose -Message "Load API data for $($resources.Function)"
         Write-Verbose -Message "Description: $($resources.Description)"
   

--- a/templates/Verb-RubrikNoun.ps1
+++ b/templates/Verb-RubrikNoun.ps1
@@ -49,7 +49,7 @@ function Verb-RubrikNoun
         
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
-    $resources = (Get-RubrikAPIData -endpoint $function).$api
+    $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   


### PR DESCRIPTION
# Description

This PR alters several things:
* RCDM versions have been added to the `Get-RubrikAPIData` function so that each endpoint has one or more versions related to the endpoint data. This allows for different endpoint options to exist across multiple versions of the software stack. For endpoints without a change at this very moment, I have set the version to a generic `1.0` value. The bottom of the script now parses through all available options for an endpoint to determine which data to load, and then returns that data to the calling (parent) function.
* The `Connect-Rubrik` function has been cleaned up since the old session endpoint is no longer supported. Much of the old code has been purged.
* The `Get-RubrikAPIVersion` and `Get-RubrikSoftwareVersion` functions do not recall auth, and as such, I have generically set them to pull data from a cluster even if a session has not been established.
* All other functions have had the `$api` value removed from their `$resources` retrieval since the version of RCDM will now ultimately dictate which endpoint data is used for the function.

## Related Issue

Fixes #159 

## Motivation and Context

This allows for complete disparate versions of the endpoint(s) to exist across major and minor versions of RCDM.

## How Has This Been Tested?

I've loaded up the new code and tested against a 4.0 and 4.1 environment. Here's the test script I used for the changed made to the reporting endpoints.

```
#$me = Get-Credential

#4.1
rmo Rubrik
ipmo .\Rubrik
Connect-Rubrik [4.1 lab] -Credential $me -Verbose
Get-RubrikReport -Name 'SLA Compliance Summary' | Get-RubrikReportData -ComplianceStatus:NonCompliance

#4.0
rmo Rubrik
ipmo .\Rubrik
Connect-Rubrik [4.0 lab] -Credential $me -Verbose
Get-RubrikReport -Name 'SLA Compliance Summary' | Get-RubrikReportData -ComplianceStatus:NonCompliance
```

Both were successful.

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
