### PR TITLE
#138: Remove readthedocs.io badge from docs/readme.md

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,6 +1,6 @@
 Community PowerShell Module for Rubrik
 ============================
 
-[![Build status](https://ci.appveyor.com/api/projects/status/52cv3jshak2w7624?svg=true)](https://ci.appveyor.com/project/chriswahl/powershell-module)   [![Documentation Status](http://readthedocs.org/projects/powershell-module/badge/?version=latest)](http://powershell-module.readthedocs.io/en/latest/?badge=latest)
+[![Build status](https://ci.appveyor.com/api/projects/status/52cv3jshak2w7624?svg=true)](https://ci.appveyor.com/project/chriswahl/powershell-module)
 
 This is a community project that provides a Microsoft PowerShell module for managing and monitoring Rubrik's Cloud Data Management fabric by way of published RESTful APIs. If you're looking to perform interactive automation, setting up scheduled tasks, leverage an orchestration engine, or need ad-hoc operations, this module is intended to be valuable to your needs.


### PR DESCRIPTION
# Description

Removes readthedocs.io badge from docs/readme.md, which I missed in pull request #139.

## Related Issue

Fixes #138

## Motivation and Context

The documentation is no longer hosted from readthedocs.io

## How Has This Been Tested?

* https://github.com/tlindsay42/PowerShell-Module/blob/RemoveReadTheDocsBadge/README.md

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/11078689/32977148-e6e5618a-cbec-11e7-9565-5e97fb8d7872.png)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
