### PR TITLE
Fix Get-RubrikVM -SLAID <slaId> does not map to query key

### DIFF
--- a/Rubrik/Public/Get-RubrikVM.ps1
+++ b/Rubrik/Public/Get-RubrikVM.ps1
@@ -81,7 +81,9 @@ function Get-RubrikVM
   Process {
 
     #region One-off
-    $SLAID = Test-RubrikSLA -SLA $SLA -Inherit $Inherit -DoNotProtect $DoNotProtect
+    if($SLAID.Length -eq 0 -and $SLA.Length -gt 0) {
+      $SLAID = Test-RubrikSLA -SLA $SLA -Inherit $Inherit -DoNotProtect $DoNotProtect
+    }
     #endregion
 
     $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $id


### PR DESCRIPTION
# Description

Adds a condition for setting the $SLAID in `#region One-off` to fix use of the SLAID parameter in the Get-RubrikVM function.  

## Related Issue

#165 

## Motivation and Context

Fixes the Get-RubrikVM -SLAID parameter functionality.

## How Has This Been Tested?

Hacked my 4.0.0.117 module and re-ran the command, as well as the `Get-RubrikVM -SLA $slaName` command, which the original logic in the One-off region fixed.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
