### PR TITLE
Automatically update Copyright year in module manifest

### DIFF
--- a/Rubrik/Rubrik.psd1
+++ b/Rubrik/Rubrik.psd1
@@ -27,7 +27,7 @@ Author = 'Chris Wahl'
 CompanyName = 'Rubrik'
 
 # Copyright statement for this module
-Copyright = '(c) 2015-2017 Rubrik, Inc. All rights reserved.'
+Copyright = '(c) 2015-2018 Rubrik, Inc. All rights reserved.'
 
 # Description of the functionality provided by this module
 Description = 'This is a community project that provides a Windows PowerShell module for managing and monitoring Rubrik''s Converged Data Management platform.'

--- a/Tests/build.ps1
+++ b/Tests/build.ps1
@@ -29,7 +29,13 @@ else
 
         # Update the manifest with the new version value and fix the weird string replace bug
         $functionList = ((Get-ChildItem -Path .\Rubrik\Public).BaseName)
-        Update-ModuleManifest -Path $manifestPath -ModuleVersion $newVersion -FunctionsToExport $functionList
+        $splat = @{
+            'Path'              = $manifestPath
+            'ModuleVersion'     = $newVersion
+            'FunctionsToExport' = $functionList
+            'Copyright'         = "(c) 2015-$( (Get-Date).Year ) Rubrik, Inc. All rights reserved."
+        }
+        Update-ModuleManifest @splat
         (Get-Content -Path $manifestPath) -replace 'PSGet_Rubrik', 'Rubrik' | Set-Content -Path $manifestPath
         (Get-Content -Path $manifestPath) -replace 'NewManifest', 'Rubrik' | Set-Content -Path $manifestPath
         (Get-Content -Path $manifestPath) -replace 'FunctionsToExport = ', 'FunctionsToExport = @(' | Set-Content -Path $manifestPath -Force


### PR DESCRIPTION
# Description

This change will automatically update the copyright year in the module manifest on build.

## Related Issue

#167 

## Motivation and Context

The copyright year in the module manifest is manually maintained at present, and out of date (2017).

## How Has This Been Tested?

```powershell
$splat = @{ 'Path'='.\Rubrik\Rubrik.psd1';'Copyright'="(c) 2015-$( (Get-Date).Year ) Rubrik, Inc. All rights reserved."}; Update-ModuleManifest @splat
```

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
