### PR TITLE
Remove Inherit choice from New-RubrikSnapshot

### DIFF
--- a/Rubrik/Public/New-RubrikSnapshot.ps1
+++ b/Rubrik/Public/New-RubrikSnapshot.ps1
@@ -17,15 +17,15 @@ function New-RubrikSnapshot
       https://github.com/rubrikinc/PowerShell-Module
 
       .EXAMPLE
-      Get-RubrikVM 'Server1' | New-RubrikSnapshot -Inherit
-      This will trigger an on-demand backup for any virtual machine named "Server1" using the existing SLA domain
+      Get-RubrikVM 'Server1' | New-RubrikSnapshot -Forever
+      This will trigger an on-demand backup for any virtual machine named "Server1" that will be retained indefinitely and available under Unmanaged Objects.
 
       .EXAMPLE
       Get-RubrikFileset 'C_Drive' | New-RubrikSnapshot -SLA 'Gold'
-      This will trigger an on-demand backup for any fileset named "C_Drive" using the "Gold" SLA Domain
+      This will trigger an on-demand backup for any fileset named "C_Drive" using the "Gold" SLA Domain.
 
       .EXAMPLE
-      Get-RubrikDatabase 'DB1' | New-RubrikSnapshot -ForceFull -Inherit
+      Get-RubrikDatabase 'DB1' | New-RubrikSnapshot -ForceFull -SLA 'Silver'
       This will trigger an on-demand backup for any database named "DB1" and force the backup to be a full rather than an incremental.
   #>
 
@@ -37,9 +37,9 @@ function New-RubrikSnapshot
     # The SLA Domain in Rubrik
     [Parameter(ParameterSetName = 'SLA_Explicit')]
     [String]$SLA,
-    # Removes the SLA Domain assignment
-    [Parameter(ParameterSetName = 'SLA_Unprotected')]
-    [Switch]$DoNotProtect,
+    # The snapshot will be retained indefinitely and available under Unmanaged Objects
+    [Parameter(ParameterSetName = 'SLA_Forever')]
+    [Switch]$Forever,
     # Whether to force a full snapshot or an incremental. Only valid with MSSQL Databases.
     [Alias('forceFullSnapshot')]
     [Switch]$ForceFull,
@@ -74,7 +74,7 @@ function New-RubrikSnapshot
   Process {
 
     #region One-off
-    $SLAID = Test-RubrikSLA -SLA $SLA -DoNotProtect $DoNotProtect
+    $SLAID = Test-RubrikSLA -SLA $SLA -DoNotProtect $Forever
     #endregion One-off
 
     $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri

--- a/Rubrik/Public/New-RubrikSnapshot.ps1
+++ b/Rubrik/Public/New-RubrikSnapshot.ps1
@@ -40,9 +40,6 @@ function New-RubrikSnapshot
     # Removes the SLA Domain assignment
     [Parameter(ParameterSetName = 'SLA_Unprotected')]
     [Switch]$DoNotProtect,
-    # Inherits the SLA Domain assignment from a parent object
-    [Parameter(ParameterSetName = 'SLA_Inherit')]
-    [Switch]$Inherit,    
     # Whether to force a full snapshot or an incremental. Only valid with MSSQL Databases.
     [Alias('forceFullSnapshot')]
     [Switch]$ForceFull,
@@ -77,7 +74,7 @@ function New-RubrikSnapshot
   Process {
 
     #region One-off
-    $SLAID = Test-RubrikSLA -SLA $SLA -Inherit $Inherit -DoNotProtect $DoNotProtect
+    $SLAID = Test-RubrikSLA -SLA $SLA -DoNotProtect $DoNotProtect
     #endregion One-off
 
     $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri


### PR DESCRIPTION
Signed-off-by: Chris Wahl <github@wahlnetwork.com>

# Description

Taking an on-demand snapshot requires either submitting the SLA ID or using the "Unprotected" type to specify that you want a relic. The option for `Inherit` was erroneous and has been removed.

This PR removes that option while updating the `DoNotProtect` param to reflect the `Forever` option that is found in the API/GUI.

## Related Issue

Fixes #171 

## Motivation and Context

The option for `Inherit` was erroneous and `DoNotProtect` was complex wording. This should make it simpler.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
