### PR TITLE
New-BodyString Fix

### DIFF
--- a/Rubrik/Private/New-BodyString.ps1
+++ b/Rubrik/Private/New-BodyString.ps1
@@ -13,7 +13,14 @@
   # Look at the list of parameters that were set by the invocation process
   # This is how we know which params were actually set by the call, versus defaulting to some zero, null, or false value
   # We can also add any custom variables here, such as SLAID which is populated after the invocation resolves the name
-  if ($slaid) {$PSCmdlet.MyInvocation.BoundParameters.Add('SLAID',$slaid)}
+  if ($slaid -and $PSCmdlet.MyInvocation.BoundParameters.ContainsKey('SLAID'))
+  {
+    $PSCmdlet.MyInvocation.BoundParameters.SLAID = $slaid
+  } 
+  elseif($slaid)
+  {
+    $PSCmdlet.MyInvocation.BoundParameters.Add('SLAID',$slaid)
+  }
   
   # Now that custom params are added, let's inventory all invoked params
   $setParameters = $pscmdlet.MyInvocation.BoundParameters


### PR DESCRIPTION
# Description
This addresses a logic bug when processing multiple objects using SLAID in New-BodyString. Originally, if SLAID was passed, the function would add it to `$PSCmdlet.MyInvocation.BoundParameters`. However, if there was another object/call (which happens when the parent is within a pipeline operation), the code would try to add it to the collection when it already was there. This code change will check if the SLAID key is in the collection, add it if it isn't there, and overwrite with the current value if it is.

## Related Issue
#155 

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
