### PR TITLE
Adding ability to do more with NAS

### DIFF
--- a/Rubrik/Public/Get-RubrikFileset.ps1
+++ b/Rubrik/Public/Get-RubrikFileset.ps1
@@ -59,6 +59,9 @@ function Get-RubrikFileset
     [Alias('primary_cluster_id')]
     [String]$PrimaryClusterID,        
     # Rubrik's fileset id
+    [Alias('share_id')]
+    [String]$ShareID,
+    # Rubrik's fileset id
     [Parameter(ValueFromPipelineByPropertyName = $true)]    
     [String]$id,
     # SLA id value

--- a/Rubrik/Public/Get-RubrikFilesetTemplate.ps1
+++ b/Rubrik/Public/Get-RubrikFilesetTemplate.ps1
@@ -38,6 +38,9 @@ function Get-RubrikFilesetTemplate
     [ValidateSet('Windows', 'Linux')]
     [Alias('operating_system_type')]
     [String]$OperatingSystemType,
+    # Filter the summary information based on the share type of the fileset. Accepted values: 'NFS', 'SMB'
+    [ValidateSet('NFS', 'SMB')]
+    [String]$shareType,
     # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use **_local** as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
     [Alias('primary_cluster_id')]
     [String]$PrimaryClusterID,    

--- a/Rubrik/Public/New-RubrikNASShare.ps1
+++ b/Rubrik/Public/New-RubrikNASShare.ps1
@@ -1,0 +1,88 @@
+﻿#requires -Version 3
+function New-RubrikNASShare
+{
+  <#  
+      .SYNOPSIS
+      Creates a new NAS share in Rubrik for backup operations
+
+      .DESCRIPTION
+      Registers a new NAS share in Rubrik. Once created, this NAS share can be associated with
+      filesets for appropriate fileset backups. Note, a host must first be created using
+      New-RubrikHost for the NAS share to be associated.
+
+      .NOTES
+      Written by Mike Fal
+      Twitter: @Mike_Fal
+      GitHub: MikeFal
+      
+      .LINK
+      https://github.com/rubrikinc/PowerShell-Module
+
+      .EXAMPLE
+      {required: show one or more examples using the function}
+  #>
+
+  [CmdletBinding(SupportsShouldProcess = $true,ConfirmImpact = 'High')]
+  Param(
+    #Host ID that the NAS share will be associated with
+    [Parameter(Mandatory = $true)]
+    [String]$HostID,
+    #Share type - NFS or SMB
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('NFS','SMB')]
+    [String]$ShareType,
+    #Export point - Share Name
+    [String]$ExportPoint,
+    #Credential for NAS share
+    [pscredential]$Credential,
+    # Rubrik server IP or FQDN
+    [String]$Server = $global:RubrikConnection.server,
+    # API version
+    [String]$api = $global:RubrikConnection.api
+  )
+
+  Begin {
+
+    # The Begin section is used to perform one-time loads of data necessary to carry out the function's purpose
+    # If a command needs to be run with each iteration or pipeline input, place it in the Process section
+    
+    # Check to ensure that a session to the Rubrik cluster exists and load the needed header data for authentication
+    Test-RubrikConnection
+    
+    # API data references the name of the function
+    # For convenience, that name is saved here to $function
+    $function = $MyInvocation.MyCommand.Name
+        
+    # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
+    Write-Verbose -Message "Gather API Data for $function"
+    $resources = Get-RubrikAPIData -endpoint $function
+    Write-Verbose -Message "Load API data for $($resources.Function)"
+    Write-Verbose -Message "Description: $($resources.Description)"
+  
+  }
+
+  Process {
+
+    $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $id
+    $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
+    $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)
+
+    #region one-off
+    #Convert credential to valid body values
+    if($Credential){
+      $bodytemp = ConvertFrom-Json $body
+      $bodytemp | Add-Member -MemberType NoteProperty -Name 'username' -Value $Credential.GetNetworkCredential().UserName
+      $bodytemp | Add-Member -MemberType NoteProperty -Name 'password' -Value $Credential.GetNetworkCredential().Password 
+      $bodytemp | Add-Member -MemberType NoteProperty -Name 'domain' -Value $Credential.GetNetworkCredential().Domain 
+      $body = ConvertTo-Json $bodytemp
+    }
+    #endregion
+
+    $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
+    $result = Test-ReturnFormat -api $api -result $result -location $resources.Result
+    $result = Test-FilterObject -filter ($resources.Filter) -result $result
+
+    return $result
+
+  } # End of process
+} # End of function


### PR DESCRIPTION
Description

get-RubrikFileset adds a share_id to support NAS filesets not just
Windows/Linux.
get-RubrikFilesetTemplate adds share type so we can pull fileset
templates that work with NFS/SMB not just Windows/Linux
New-RubrikNASShare allows adding NAS shares via the API

Related Issue
Issue was you could not add NAS shares via a powershell module

Motivation and Context
Have a customer that needs to add 1,500 shares to Rubrik and doesn't want to do it one at a time.

How Has This Been Tested?
Yes, added multiple shares to Rubrik on 4.1

X -  New feature (non-breaking change which adds functionality)

Checklist:
Go over all the following points, and put an x in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

 My code follows the code style of this project.
 My change requires a change to the documentation.
 I have updated the documentation accordingly.
 I have read the CONTRIBUTION document.
 I have updated the CHANGELOG file accordingly for the version that this merge modifies.
 I have added tests to cover my changes.
 All new and existing tests passed.