### PR TITLE
Added -PrimaryClusterID to Move-RubrikMountVMDK

### DIFF
--- a/Rubrik/Public/Move-RubrikMountVMDK.ps1
+++ b/Rubrik/Public/Move-RubrikMountVMDK.ps1
@@ -90,10 +90,10 @@ function Move-RubrikMountVMDK
         $Date = Get-Date
       }
 
-      $HostID = (Get-RubrikVM -VM $TargetVM).hostId
-
-      Write-Verbose -Message "Creating a powered off Live Mount of $SourceVM"
-      $mount = Get-RubrikVM $SourceVM | Get-RubrikSnapshot -Date $Date | New-RubrikMount -HostID $HostID
+      $HostID = (Get-RubrikVM -VM $TargetVM -PrimaryClusterID local).hostId
+ 
+      Write-Verbose -Message "Creating a powered off Live Mount of $SourceVM(local)"
+      $mount = Get-RubrikVM $SourceVM -PrimaryClusterID local | Get-RubrikSnapshot -Date $Date | New-RubrikMount -HostID $HostID
     
       Write-Verbose -Message "Waiting for request $($mount.id) to complete"
       while ((Get-RubrikRequest -ID $mount.id -Type "vmware/vm").status -ne 'SUCCEEDED')
@@ -115,7 +115,7 @@ function Move-RubrikMountVMDK
       }
 
       Write-Verbose -Message 'Gathering details on the Live Mount'
-      $MountVM = Get-RubrikVM -id (Get-RubrikMount -id $MountID).mountedVmId
+      $MountVM = Get-RubrikVM -id (Get-RubrikMount -id $MountID).mountedVmId -PrimaryClusterID local
 
       Write-Verbose -Message 'Gathering details on the Target VM'
       $TargetHost = Get-VMHost -VM $TargetVM


### PR DESCRIPTION
# Description

Get-RubrikVM requires a cluster ID to return the correct VM in the event of VMs being replicated. For the purposes of this function, we assume that all activities will be done with VMs on the local Rubrik cluster, this `-PrimaryClusterID local` was added to all Get-RubrikVM calls.

## Related Issue

Small fix, being lazy and not opening an issue.

## Motivation and Context

Bug fix

## How Has This Been Tested?

Validated fix in the Rubrik SE lab against demo Kroll and Exchange servers.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
