### PR TITLE
Bug fix for Move-RubrikMountVMDK

### DIFF
--- a/Rubrik/Public/Move-RubrikMountVMDK.ps1
+++ b/Rubrik/Public/Move-RubrikMountVMDK.ps1
@@ -17,6 +17,11 @@ function Move-RubrikMountVMDK
       https://github.com/rubrikinc/PowerShell-Module
 
       .EXAMPLE
+      Move-RubrikMountVMDK -SourceVMID (Get-RubrikVM -Name 'SourceVM').id -TargetVM 'TargetVM'
+      This will create a Live Mount using the latest snapshot of the VM named "SourceVM", using the VM's Rubrik ID.
+      The Live Mount's VMDKs would then be presented to the VM named "TargetVM"
+
+      .EXAMPLE
       Move-RubrikMountVMDK -SourceVM 'SourceVM' -TargetVM 'TargetVM'
       This will create a Live Mount using the latest snapshot of the VM named "SourceVM"
       The Live Mount's VMDKs would then be presented to the VM named "TargetVM"

--- a/Rubrik/Public/Move-RubrikMountVMDK.ps1
+++ b/Rubrik/Public/Move-RubrikMountVMDK.ps1
@@ -45,22 +45,23 @@ function Move-RubrikMountVMDK
 
   [CmdletBinding(SupportsShouldProcess = $true,ConfirmImpact = 'High')]
   Param(
+    # Source virtual machine Rubrik ID to use as a live mount
+    [Parameter(ParameterSetName = 'Create')]
+    [String]$SourceVMID,
     # Source virtual machine to use as a Live Mount based on a previous backup
-    [Parameter(Mandatory = $true,Position = 0,ValueFromPipeline = $true,ParameterSetName = 'Create')]
+    [Parameter(ParameterSetName = 'Create')]
     [Alias('Name','VM')]
-    [ValidateNotNullorEmpty()]
     [String]$SourceVM,
     # Target virtual machine to attach the Live Mount disk(s)
-    [Parameter(Mandatory = $true,Position = 1,ParameterSetName = 'Create')]
-    [ValidateNotNullorEmpty()]
+    [Parameter(Mandatory=$true,ParameterSetName = 'Create')]
     [String]$TargetVM,
     # Backup date to use for the Live Mount
     # Will use the current date and time if no value is specified
-    [Parameter(Position = 2,ParameterSetName = 'Create')]
+    [Parameter(ParameterSetName = 'Create')]
     [String]$Date,
     # An array of disks to exclude from presenting to the target virtual machine
     # By default, all disks will be presented
-    [Parameter(Position = 3,ParameterSetName = 'Create')]
+    [Parameter(ParameterSetName = 'Create')]
     [Array]$ExcludeDisk,
     # The path to a cleanup file to remove the live mount and presented disks
     # The cleanup file is created each time the command is run and stored in the $HOME path as a text file with a random number value
@@ -77,11 +78,11 @@ function Move-RubrikMountVMDK
 
     Test-RubrikConnection
     Test-VMwareConnection
-  
+
   }
 
   Process {
-
+    try{
     if (!$Cleanup)
     {
       if (!$Date) 
@@ -90,11 +91,26 @@ function Move-RubrikMountVMDK
         $Date = Get-Date
       }
 
+      Write-Verbose -Message "Validating Source and Target VMs"
+      if($SourceVM -and !$SourceVMID){
+        Write-Warning -Message "-SourceVM has been deprecated as a parameter. The code will attempt to match the correct Rubrik VM ID, but please use -SourceVMID."
+        $SourceVMID = (Get-RubrikVM -Name $SourceVM -PrimaryClusterID local).id
+        if(!$SourceVMID){
+          throw "$SourceVM is invalid. Please use a valid VM."
+        } elseif ($SourceVMID.Count -gt 1) {
+          throw "$souceVM has mutliple results. Please use -SourceVMID to specific the VM you want to use."
+        }
+      }
+
       $HostID = (Get-RubrikVM -VM $TargetVM -PrimaryClusterID local).hostId
- 
-      Write-Verbose -Message "Creating a powered off Live Mount of $SourceVM(local)"
-      $mount = Get-RubrikVM $SourceVM -PrimaryClusterID local | Get-RubrikSnapshot -Date $Date | New-RubrikMount -HostID $HostID
-    
+      if(!$HostID){
+        throw "$targetvm is invalid."
+      }
+      Write-Verbose -Message "Creating a powered off Live Mount of $SourceVMID)"
+      $mount = Get-RubrikSnapshot -id $SourceVMID -Date $Date | New-RubrikMount -HostID $HostID
+      
+      if(-not $mount) {throw 'No mounts were created. Check that you have declared a valid VM.'}
+
       Write-Verbose -Message "Waiting for request $($mount.id) to complete"
       while ((Get-RubrikRequest -ID $mount.id -Type "vmware/vm").status -ne 'SUCCEEDED')
       {
@@ -103,6 +119,7 @@ function Move-RubrikMountVMDK
     
       Write-Verbose -Message 'Live Mount is now available'
       Write-Verbose -Message 'Gathering Live Mount ID value'
+      
       foreach ($link in ((Get-RubrikRequest -ID $mount.id -Type "vmware/vm").links))
       {
         # There are two links - the request (self) and result
@@ -116,10 +133,7 @@ function Move-RubrikMountVMDK
 
       Write-Verbose -Message 'Gathering details on the Live Mount'
       $MountVM = Get-RubrikVM -id (Get-RubrikMount -id $MountID).mountedVmId -PrimaryClusterID local
-
-      Write-Verbose -Message 'Gathering details on the Target VM'
-      $TargetHost = Get-VMHost -VM $TargetVM
-
+      
       Write-Verbose -Message 'Migrating the Mount VMDKs to VM'
       if ($PSCmdlet.ShouldProcess($TargetVM,'Migrating Live Mount VMDK(s)'))
       {
@@ -154,7 +168,7 @@ function Move-RubrikMountVMDK
       $TargetVM | Out-File -FilePath $Diskfile -Encoding utf8 -Force
       $MountID | Out-File -FilePath $Diskfile -Encoding utf8 -Append -Force      
       $MountedVMdiskFileNames | Out-File -FilePath $Diskfile -Encoding utf8 -Append -Force
-
+      
       # Return information needed to cleanup the mounted disks and Live Mount      
       $response = @{}
       $response.Add('Status','Success')
@@ -186,6 +200,13 @@ function Move-RubrikMountVMDK
       Write-Verbose -Message "Deleting the Live Mount named $($MountVM.name)"
       Remove-RubrikMount -id $MountID -Confirm:$false
     }
+    } #end Try
+    catch {
+      #IF any error occurs, bail out of the script before any damage is done.
+      throw $_
+      break
+
+    } #end Catch
 
   } # End of process
 } # End of function


### PR DESCRIPTION
# Description
This fix addresses the destructive bug that currently exists in Move-RubrikMountVMDK by adding error handling, new parameters, and input sanitation. The details of these changes are:

- **Error handling**: Function now contains a try/catch block that will force the script to return the error and break/exit the function. This is intended to stop execution before function reaches a point where it can unintentionally remove disks.
- **New/Changed Parameters**: To ensure accuracy, SourcVMID was added so that more accurate execution can be ensured. SourceVM (name) has been marked as deprecated. While the parameter is still valid, it will throw a warning that the parameter is deprecated.
- **Input Sanitation**: Checks have been put in place to validate the source VM. If these checks fail, an error will be thrown, causing the function to end.

## Related Issue
#202 

## Motivation and Context
Without the error handling, the function will continue on error. This can cause random unmounting of live disks from VMs.

## How Has This Been Tested?
Test in Ranger lab poc-vcsa. Checked several test cases:

- Error: Cross VCenter mounting (throw+break succeeded)
- Error: No snapshot exists for mounting (throw+break succeeded)
- Success: VMName
- Error: Multiple VM IDs (parameter validation error, stopped)
- Success: Single VM ID

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
